### PR TITLE
Fix syscheck queue/restart races and honor FIM frequency under realtime.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -107,6 +107,9 @@ testsuite/*.changes
 testsuite/*.buildinfo
 testsuite/*.tar.gz
 testsuite/*.tar.xz
+testsuite/e2e-linux/inventory.community.yaml
+testsuite/e2e-linux/mock-rocky10/
+testsuite/e2e-linux/.enroll.out
 
 # Pbuilder prepared source (generate_ossec.sh -d writes here)
 contrib/debian-packages/build/

--- a/src/analysisd/analysisd.c
+++ b/src/analysisd/analysisd.c
@@ -371,6 +371,16 @@ int main_analysisd(int argc, char **argv)
     }
     nowChroot();
 
+    /* Bind the analysis queue early (before decoder/rule load) so producers
+     * started by ossec-control do not connect to a stale socket path while
+     * we are still loading config. Group is already set; socket is 0660.
+     */
+    if (!test_config) {
+        if ((m_queue = StartMQ(DEFAULTQUEUE, READ)) < 0) {
+            ErrorExit(QUEUE_ERROR, ARGV0, DEFAULTQUEUE, strerror(errno));
+        }
+    }
+
     Config.decoder_order_size = (size_t)getDefine_Int("analysisd", "decoder_order_size", 8, MAX_DECODER_ORDER_SIZE);
 
 
@@ -545,10 +555,7 @@ int main_analysisd(int argc, char **argv)
         ErrorExit(PID_ERROR, ARGV0);
     }
 
-    /* Set the queue */
-    if ((m_queue = StartMQ(DEFAULTQUEUE, READ)) < 0) {
-        ErrorExit(QUEUE_ERROR, ARGV0, DEFAULTQUEUE, strerror(errno));
-    }
+    /* Queue already bound post-chroot (see StartMQ above). */
 
     /* allowlist */
     if (Config.allow_list == NULL) {

--- a/src/analysisd/pipeline.c
+++ b/src/analysisd/pipeline.c
@@ -30,8 +30,10 @@
 #endif
 
 #include <errno.h>
+#include <poll.h>
 #include <signal.h>
 #include <stdint.h>
+#include <sys/socket.h>
 #include <time.h>
 #include <unistd.h>
 
@@ -67,8 +69,8 @@ os_queue *writer_queue_firewall = NULL;
 os_queue *writer_queue_fts = NULL;
 os_queue *raw_input_queue = NULL;
 
-static volatile int analysisd_shutting_down = 0;
-static int pipeline_m_queue = 0;
+static volatile sig_atomic_t analysisd_shutting_down = 0;
+static volatile sig_atomic_t pipeline_m_queue = -1;
 static volatile long alert_ticket = 0;
 
 static int cfg_event_threads = 1;
@@ -926,14 +928,38 @@ static void *analysisd_input_recv_thread(void *arg)
     char msg[OS_MAXSTR + 1];
     char *copy;
     int recv_len;
+    struct pollfd pfd;
 
     (void)arg;
     os_block_worker_signals();
 
     while (!analysisd_shutting_down) {
-        recv_len = OS_RecvUnix(pipeline_m_queue, OS_MAXSTR, msg);
+        int fd = (int)pipeline_m_queue;
+
+        if (fd < 0) {
+            break;
+        }
+
+        pfd.fd = fd;
+        pfd.events = POLLIN;
+        pfd.revents = 0;
+
+        /* Short poll so shutdown flag / closed FD is observed promptly. */
+        if (poll(&pfd, 1, 1000) <= 0) {
+            continue;
+        }
+
+        if (analysisd_shutting_down || (int)pipeline_m_queue < 0) {
+            break;
+        }
+
+        if (!(pfd.revents & (POLLIN | POLLHUP | POLLERR))) {
+            continue;
+        }
+
+        recv_len = OS_RecvUnix(fd, OS_MAXSTR, msg);
         if (recv_len <= 0) {
-            if (analysisd_shutting_down) {
+            if (analysisd_shutting_down || (int)pipeline_m_queue < 0) {
                 break;
             }
             continue;
@@ -961,6 +987,20 @@ static void *analysisd_input_recv_thread(void *arg)
     }
 
     return NULL;
+}
+
+static void analysisd_close_input_queue(void)
+{
+    int fd = (int)pipeline_m_queue;
+
+    if (fd < 0) {
+        return;
+    }
+
+    /* Publish closed state before shutdown/close so the recv loop exits. */
+    pipeline_m_queue = -1;
+    (void)shutdown(fd, SHUT_RDWR);
+    (void)close(fd);
 }
 
 static void *analysisd_input_demux_thread(void *arg)
@@ -994,6 +1034,9 @@ static void *analysisd_input_demux_thread(void *arg)
 void analysisd_pipeline_request_shutdown(void)
 {
     analysisd_shutting_down = 1;
+    /* Wake input_recv if it is blocked in poll/recv (producers may already
+     * be dead, so no datagrams arrive to unblock a plain recvfrom). */
+    analysisd_close_input_queue();
 }
 
 void analysisd_log_pipeline_metrics(unsigned int decoded, unsigned int processed,
@@ -1093,10 +1136,7 @@ void analysisd_pipeline_shutdown(void)
     analysisd_state_shutdown();
 
     /* Stage 1: stop accepting new messages, then drain decode input. */
-    if (pipeline_m_queue >= 0) {
-        close(pipeline_m_queue);
-        pipeline_m_queue = -1;
-    }
+    analysisd_close_input_queue();
 
     if (analysisd_join_thread(input_recv_thread_id, "input recv thread") != 0) {
         join_failed = 1;

--- a/src/init/ossec-client.sh
+++ b/src/init/ossec-client.sh
@@ -135,6 +135,15 @@ start()
             fi
 
             echo "Started ${i}..."
+
+            # Agent queue owner is ossec-agentd (local producers connect to it).
+            if [ X"$i" = "Xossec-agentd" ]; then
+                wait_for_agent_queue
+                if [ $? != 0 ]; then
+                    unlock;
+                    exit 1;
+                fi
+            fi
         else
             echo "${i} already running..."
         fi
@@ -176,16 +185,56 @@ pstatus()
     return 0;
 }
 
+wait_pids_gone()
+{
+    local grace=45
+    local elapsed=0
+    local pid
+    local still
+
+    if [ "X$*" = "X" ]; then
+        return 0
+    fi
+
+    while [ ${elapsed} -lt ${grace} ]; do
+        still=0
+        for pid in $*; do
+            kill -0 ${pid} >/dev/null 2>&1
+            if [ $? = 0 ]; then
+                still=1
+                break
+            fi
+        done
+        if [ ${still} = 0 ]; then
+            return 0
+        fi
+        sleep 1
+        elapsed=`expr ${elapsed} + 1`
+    done
+
+    for pid in $*; do
+        kill -0 ${pid} >/dev/null 2>&1
+        if [ $? = 0 ]; then
+            echo "Process ${pid} did not exit; sending SIGKILL .."
+            kill -9 ${pid} >/dev/null 2>&1
+        fi
+    done
+    sleep 1
+}
+
 stopa()
 {
     lock;
     checkpid;
+    WAIT_PIDS=""
     for i in ${DAEMONS}; do
         pstatus ${i};
         if [ $? = 1 ]; then
             echo "Killing ${i} .. ";
-
-            kill `cat ${DIR}/var/run/${i}*.pid`;
+            for j in `cat ${DIR}/var/run/${i}*.pid 2>/dev/null`; do
+                kill ${j} >/dev/null 2>&1
+                WAIT_PIDS="${WAIT_PIDS} ${j}"
+            done
         else
             echo "${i} not running ..";
         fi
@@ -193,8 +242,43 @@ stopa()
         rm -f ${DIR}/var/run/${i}*.pid
      done
 
+    wait_pids_gone ${WAIT_PIDS}
+
+    rm -f ${DIR}/queue/ossec/queue 2>/dev/null
+
     unlock;
     echo "$NAME $VERSION Stopped"
+}
+
+wait_for_agent_queue()
+{
+    local elapsed=0
+    local max=60
+    local qpath="${DIR}/queue/ossec/queue"
+
+    while [ ${elapsed} -lt ${max} ]; do
+        if [ -S "${qpath}" ] || [ -e "${qpath}" ]; then
+            python3 - "${qpath}" <<'PY' 2>/dev/null
+import socket, sys
+path = sys.argv[1]
+s = socket.socket(socket.AF_UNIX, socket.SOCK_DGRAM)
+try:
+    s.connect(path)
+except Exception:
+    sys.exit(1)
+finally:
+    s.close()
+sys.exit(0)
+PY
+            if [ $? = 0 ]; then
+                return 0
+            fi
+        fi
+        sleep 1
+        elapsed=`expr ${elapsed} + 1`
+    done
+    echo "ERROR: agent queue not ready at ${qpath} after ${max}s"
+    return 1
 }
 
 ### MAIN HERE ###
@@ -210,7 +294,6 @@ stop)
 restart)
     testconfig
     stopa
-    sleep 1;
     start
     ;;
 reload)

--- a/src/init/ossec-local.sh
+++ b/src/init/ossec-local.sh
@@ -200,6 +200,14 @@ start()
                 exit 1;
             fi
             echo "Started ${i}..."
+
+            if [ X"$i" = "Xossec-analysisd" ]; then
+                wait_for_analysis_queue
+                if [ $? != 0 ]; then
+                    unlock;
+                    exit 1;
+                fi
+            fi
         else
             echo "${i} already running..."
         fi
@@ -249,20 +257,65 @@ pstatus()
     return 0;
 }
 
+wait_pids_gone()
+{
+    local grace=45
+    local elapsed=0
+    local pid
+    local still
+
+    if [ "X$*" = "X" ]; then
+        return 0
+    fi
+
+    while [ ${elapsed} -lt ${grace} ]; do
+        still=0
+        for pid in $*; do
+            kill -0 ${pid} >/dev/null 2>&1
+            if [ $? = 0 ]; then
+                still=1
+                break
+            fi
+        done
+        if [ ${still} = 0 ]; then
+            return 0
+        fi
+        sleep 1
+        elapsed=`expr ${elapsed} + 1`
+    done
+
+    for pid in $*; do
+        kill -0 ${pid} >/dev/null 2>&1
+        if [ $? = 0 ]; then
+            echo "Process ${pid} did not exit; sending SIGKILL .."
+            kill -9 ${pid} >/dev/null 2>&1
+        fi
+    done
+    sleep 1
+}
+
 stopa()
 {
     lock;
     checkpid;
+    WAIT_PIDS=""
     for i in ${DAEMONS}; do
         pstatus ${i};
         if [ $? = 1 ]; then
             echo "Killing ${i} .. ";
-            kill `cat ${DIR}/var/run/${i}*.pid`;
+            for j in `cat ${DIR}/var/run/${i}*.pid 2>/dev/null`; do
+                kill ${j} >/dev/null 2>&1
+                WAIT_PIDS="${WAIT_PIDS} ${j}"
+            done
         else
             echo "${i} not running ..";
         fi
         rm -f ${DIR}/var/run/${i}*.pid
     done
+
+    wait_pids_gone ${WAIT_PIDS}
+
+    rm -f ${DIR}/queue/ossec/queue 2>/dev/null
 
     unlock;
 
@@ -273,6 +326,37 @@ stopa()
         ${DIR}/ossec-agent/bin/ossec-control stop
     fi
     echo "$NAME $VERSION Stopped"
+}
+
+wait_for_analysis_queue()
+{
+    local elapsed=0
+    local max=60
+    local qpath="${DIR}/queue/ossec/queue"
+
+    while [ ${elapsed} -lt ${max} ]; do
+        if [ -S "${qpath}" ] || [ -e "${qpath}" ]; then
+            python3 - "${qpath}" <<'PY' 2>/dev/null
+import socket, sys
+path = sys.argv[1]
+s = socket.socket(socket.AF_UNIX, socket.SOCK_DGRAM)
+try:
+    s.connect(path)
+except Exception:
+    sys.exit(1)
+finally:
+    s.close()
+sys.exit(0)
+PY
+            if [ $? = 0 ]; then
+                return 0
+            fi
+        fi
+        sleep 1
+        elapsed=`expr ${elapsed} + 1`
+    done
+    echo "ERROR: analysis queue not ready at ${qpath} after ${max}s"
+    return 1
 }
 
 ### MAIN HERE ###
@@ -288,7 +372,6 @@ stop)
 restart)
     testconfig
     stopa
-    sleep 1;
     start
     ;;
 status)

--- a/src/init/ossec-server.sh
+++ b/src/init/ossec-server.sh
@@ -223,6 +223,15 @@ start()
             fi
 
             echo "Started ${i}..."
+
+            # Producers must not start until analysisd has bound the queue.
+            if [ X"$i" = "Xossec-analysisd" ]; then
+                wait_for_analysis_queue
+                if [ $? != 0 ]; then
+                    unlock;
+                    exit 1;
+                fi
+            fi
         else
             echo "${i} already running..."
         fi
@@ -264,24 +273,105 @@ pstatus()
     return 0;
 }
 
+# After SIGTERM, wait for process exit (analysisd may need a few seconds to
+# drain). Escalate to SIGKILL after grace so restart does not race a half-dead
+# daemon.
+wait_pids_gone()
+{
+    local grace=45
+    local elapsed=0
+    local pid
+    local still
+
+    if [ "X$*" = "X" ]; then
+        return 0
+    fi
+
+    while [ ${elapsed} -lt ${grace} ]; do
+        still=0
+        for pid in $*; do
+            kill -0 ${pid} >/dev/null 2>&1
+            if [ $? = 0 ]; then
+                still=1
+                break
+            fi
+        done
+        if [ ${still} = 0 ]; then
+            return 0
+        fi
+        sleep 1
+        elapsed=`expr ${elapsed} + 1`
+    done
+
+    for pid in $*; do
+        kill -0 ${pid} >/dev/null 2>&1
+        if [ $? = 0 ]; then
+            echo "Process ${pid} did not exit; sending SIGKILL .."
+            kill -9 ${pid} >/dev/null 2>&1
+        fi
+    done
+    sleep 1
+}
+
 stopa()
 {
     lock;
     checkpid;
+    WAIT_PIDS=""
     for i in ${DAEMONS}; do
         pstatus ${i};
         if [ $? = 1 ]; then
             echo "Killing ${i} .. ";
-
-            kill `cat ${DIR}/var/run/${i}*.pid`;
+            for j in `cat ${DIR}/var/run/${i}*.pid 2>/dev/null`; do
+                kill ${j} >/dev/null 2>&1
+                WAIT_PIDS="${WAIT_PIDS} ${j}"
+            done
         else
             echo "${i} not running ..";
         fi
         rm -f ${DIR}/var/run/${i}*.pid
     done
 
+    wait_pids_gone ${WAIT_PIDS}
+
+    # Drop stale analysis queue path so the next StartMQ(WRITE) cannot
+    # connect to a dead peer inode left behind after stop.
+    rm -f ${DIR}/queue/ossec/queue 2>/dev/null
+
     unlock;
     echo "$NAME $VERSION Stopped"
+}
+
+# Wait until DEFAULTQUEUE accepts a datagram connect (analysisd early-bind).
+wait_for_analysis_queue()
+{
+    local elapsed=0
+    local max=60
+    local qpath="${DIR}/queue/ossec/queue"
+
+    while [ ${elapsed} -lt ${max} ]; do
+        if [ -S "${qpath}" ] || [ -e "${qpath}" ]; then
+            python3 - "${qpath}" <<'PY' 2>/dev/null
+import socket, sys
+path = sys.argv[1]
+s = socket.socket(socket.AF_UNIX, socket.SOCK_DGRAM)
+try:
+    s.connect(path)
+except Exception:
+    sys.exit(1)
+finally:
+    s.close()
+sys.exit(0)
+PY
+            if [ $? = 0 ]; then
+                return 0
+            fi
+        fi
+        sleep 1
+        elapsed=`expr ${elapsed} + 1`
+    done
+    echo "ERROR: analysis queue not ready at ${qpath} after ${max}s"
+    return 1
 }
 
 ### MAIN HERE ###
@@ -297,7 +387,6 @@ stop)
 restart)
     testconfig
     stopa
-    sleep 1;
     start
     ;;
 reload)

--- a/src/os_net/os_net.c
+++ b/src/os_net/os_net.c
@@ -229,10 +229,8 @@ int OS_BindUnixDomain(const char *path, mode_t mode, int max_msg_size)
     socklen_t optlen = sizeof(len);
 
     /* Make sure the path isn't there */
-    int urc = -1;
-    if (( urc = unlink(path)) < 0) {
-        /* XXX I think we're blindly unlinking path, so if it doesn't exist, don't log an error */
-        if (urc != ENOENT) {
+    if (unlink(path) < 0) {
+        if (errno != ENOENT) {
             merror("ERROR: Cannot unlink file %s: %s", path, strerror(errno));
         }
     }

--- a/src/shared/mq_op.c
+++ b/src/shared/mq_op.c
@@ -17,21 +17,26 @@
  * nested sleep ladders (see PR #578 / @awiddersheim).
  */
 
-/* Wait for the queue socket path to appear. Returns 0 if present, -1 if not.
- * delays[] are sleeps between existence checks (total wait 1+5+15 = 21s).
+/* Wait until a live AF_UNIX connect succeeds (not merely path presence).
+ * Stale socket files left after analysisd exit otherwise look "ready".
+ * Returns a connected fd, or -1 on timeout/failure.
  */
-static int mq_wait_for_path(const char *path, const unsigned int *delays, size_t ndelays)
+static int mq_wait_connect(const char *path, const unsigned int *delays,
+                           size_t ndelays)
 {
     size_t i;
+    int rc;
 
-    if (File_DateofChange(path) >= 0) {
-        return (0);
+    rc = OS_ConnectUnixDomain(path, OS_MAXSTR + 256);
+    if (rc >= 0) {
+        return (rc);
     }
 
     for (i = 0; i < ndelays; i++) {
         sleep(delays[i]);
-        if (File_DateofChange(path) >= 0) {
-            return (0);
+        rc = OS_ConnectUnixDomain(path, OS_MAXSTR + 256);
+        if (rc >= 0) {
+            return (rc);
         }
     }
 
@@ -42,29 +47,18 @@ static int mq_wait_for_path(const char *path, const unsigned int *delays, size_t
 int StartMQ(const char *path, short int type)
 {
     int rc;
-    size_t i;
-    static const unsigned int path_waits[] = { 1, 5, 15 };
-    static const unsigned int connect_waits[] = { 1, 2 };
+    /* Total sleep budget similar to historical 1+5+15 path wait + connect. */
+    static const unsigned int connect_waits[] = { 1, 2, 5, 10, 15 };
 
     if (type == READ) {
         return (OS_BindUnixDomain(path, 0660, OS_MAXSTR + 512));
     }
 
-    /* Give the other end up to 21 seconds to create the socket. */
-    if (mq_wait_for_path(path, path_waits,
-                         sizeof(path_waits) / sizeof(path_waits[0])) < 0) {
-        merror(QUEUE_ERROR, __local_name, path, "Queue not found");
-        return (-1);
-    }
-
-    /* Up to 3 connect attempts with 1s then 2s between failures (~3s sleeps). */
-    rc = OS_ConnectUnixDomain(path, OS_MAXSTR + 256);
-    for (i = 0; rc < 0 && i < sizeof(connect_waits) / sizeof(connect_waits[0]); i++) {
-        sleep(connect_waits[i]);
-        rc = OS_ConnectUnixDomain(path, OS_MAXSTR + 256);
-    }
+    rc = mq_wait_connect(path, connect_waits,
+                         sizeof(connect_waits) / sizeof(connect_waits[0]));
     if (rc < 0) {
-        merror(QUEUE_ERROR, __local_name, path, strerror(errno));
+        merror(QUEUE_ERROR, __local_name, path,
+               (File_DateofChange(path) < 0) ? "Queue not found" : strerror(errno));
         return (-1);
     }
 
@@ -110,8 +104,8 @@ int SendMSG(int queue, const char *message, const char *locmsg, char loc)
     }
 
     /* Five send attempts; after the first failure, sleep 1/3/5/10s
-     * between retries (total sleep budget 19s). OS_SOCKTERR is fatal
-     * only on the initial attempt, matching historical behavior.
+     * between retries (total sleep budget 19s). On OS_SOCKTERR close the
+     * fd so callers can StartMQ again; they see -1 as before.
      */
     __mq_rcode = OS_SendUnix(queue, tmpstr, 0);
     if (__mq_rcode < 0) {

--- a/src/syscheckd/run_check.c
+++ b/src/syscheckd/run_check.c
@@ -31,9 +31,43 @@
 /* Prototypes */
 static void send_sk_db(void);
 static void syscheck_log_send_failures(void);
+static time_t syscheck_idle_wait(time_t curr_time, time_t prev_time_sk,
+                                 time_t prev_time_rk);
 
 /* Count of baseline/update messages that could not reach the agent queue. */
 static unsigned int syscheck_send_failures = 0;
+
+/* Max idle between daemon-loop iterations: honor <frequency> / rootcheck
+ * cadence while still capping at SYSCHECK_WAIT so long frequencies do not
+ * block forever in select/sleep.
+ */
+static time_t syscheck_idle_wait(time_t curr_time, time_t prev_time_sk,
+                                 time_t prev_time_rk)
+{
+    time_t remaining;
+    time_t next_sk;
+    time_t sk_remain;
+
+    next_sk = prev_time_sk + (time_t)syscheck.time;
+    sk_remain = next_sk - curr_time;
+    remaining = sk_remain;
+
+    if (syscheck.rootcheck && rootcheck.time > 0) {
+        time_t next_rk = prev_time_rk + (time_t)rootcheck.time;
+        time_t rk_remain = next_rk - curr_time;
+        if (rk_remain < remaining) {
+            remaining = rk_remain;
+        }
+    }
+
+    if (remaining < 1) {
+        remaining = 1;
+    }
+    if (remaining > SYSCHECK_WAIT) {
+        remaining = SYSCHECK_WAIT;
+    }
+    return remaining;
+}
 
 
 /* Send a message related to syscheck change/addition.
@@ -208,9 +242,11 @@ void start_daemon()
         }
     }
 
-    /* Check every SYSCHECK_WAIT */
+    /* Loop: run due scans, then idle up to min(SYSCHECK_WAIT, remaining freq). */
     while (1) {
         int run_now = 0;
+        int select_rc;
+        time_t idle_wait;
         curr_time = time(0);
 
         /* Check if syscheck should be restarted */
@@ -302,41 +338,45 @@ void start_daemon()
             prev_time_sk = time(0);
         }
 
+        curr_time = time(0);
+        idle_wait = syscheck_idle_wait(curr_time, prev_time_sk, prev_time_rk);
+
 #ifdef INOTIFY_ENABLED
         if (syscheck.realtime && (syscheck.realtime->fd >= 0)) {
-            selecttime.tv_sec = SYSCHECK_WAIT;
+            selecttime.tv_sec = (long)idle_wait;
             selecttime.tv_usec = 0;
 
             /* zero-out the fd_set */
             FD_ZERO (&rfds);
             FD_SET(syscheck.realtime->fd, &rfds);
 
-            run_now = select(syscheck.realtime->fd + 1, &rfds,
-                             NULL, NULL, &selecttime);
-            if (run_now < 0) {
+            select_rc = select(syscheck.realtime->fd + 1, &rfds,
+                               NULL, NULL, &selecttime);
+            if (select_rc < 0) {
                 merror("%s: ERROR: Select failed (for realtime fim).", ARGV0);
-                sleep(SYSCHECK_WAIT);
-            } else if (run_now == 0) {
-                /* Timeout */
+                sleep((unsigned int)idle_wait);
+            } else if (select_rc == 0) {
+                /* Timeout — re-evaluate frequency */
             } else if (FD_ISSET (syscheck.realtime->fd, &rfds)) {
                 realtime_process();
             }
         } else {
-            sleep(SYSCHECK_WAIT);
+            sleep((unsigned int)idle_wait);
         }
 #elif defined(WIN32)
         if (syscheck.realtime && (syscheck.realtime->fd >= 0)) {
-            if (WaitForSingleObjectEx(syscheck.realtime->evt, SYSCHECK_WAIT * 1000, TRUE) == WAIT_FAILED) {
+            if (WaitForSingleObjectEx(syscheck.realtime->evt,
+                                      (DWORD)(idle_wait * 1000), TRUE) == WAIT_FAILED) {
                 merror("%s: ERROR: WaitForSingleObjectEx failed (for realtime fim).", ARGV0);
-                sleep(SYSCHECK_WAIT);
+                sleep((unsigned int)idle_wait);
             } else {
                 sleep(1);
             }
         } else {
-            sleep(SYSCHECK_WAIT);
+            sleep((unsigned int)idle_wait);
         }
 #else
-        sleep(SYSCHECK_WAIT);
+        sleep((unsigned int)idle_wait);
 #endif
     }
 }

--- a/testsuite/README.md
+++ b/testsuite/README.md
@@ -84,3 +84,15 @@ make -f tests/regressions/Makefile check
 sid-list overflow free-safety, auth IPv6 key handling, and `os_queue` timedwait
 (used by the always-on analysisd pipeline). See
 [`src/tests/regressions/README.md`](../src/tests/regressions/README.md).
+
+### Linux install / upgrade / feature E2E
+
+Separate from compile containers: [`e2e-linux/`](e2e-linux/) drives real installs over **SSH** (community Rocky 10 server) or **Podman** systemd targets. See [`e2e-linux/README.md`](e2e-linux/README.md).
+
+```bash
+# Compile all distros, then E2E (E2E args required or E2E is skipped)
+./testsuite/run-all.sh --inventory testsuite/e2e-linux/inventory.community.yaml --backend ssh
+
+# E2E only
+./testsuite/e2e-linux/run.sh --inventory testsuite/e2e-linux/inventory.community.yaml
+```

--- a/testsuite/e2e-linux/README.md
+++ b/testsuite/e2e-linux/README.md
@@ -1,0 +1,89 @@
+# Linux end-to-end tests (install / upgrade / feature smoke)
+
+This module is **separate** from the compile matrix in [`../build-test/`](../build-test/).
+It validates real installs on:
+
+- **Dedicated hosts** over SSH (community primary: Rocky Linux 10 at `root@10.66.6.82`)
+- **Podman** systemd containers (local / CI-friendly)
+
+Windows E2E is out of scope here.
+
+## Quick start
+
+From the **repo root**:
+
+```bash
+# Compile gate then E2E (optional wrapper)
+./testsuite/run-all.sh --inventory testsuite/e2e-linux/inventory.community.yaml --backend ssh
+
+# E2E only
+./testsuite/e2e-linux/run.sh --inventory testsuite/e2e-linux/inventory.community.yaml
+
+# Single suite / backend
+./testsuite/e2e-linux/run.sh --inventory ... --backend podman --suite 01-install-server
+```
+
+Copy [`inventory.example.yaml`](inventory.example.yaml) to `inventory.community.yaml` (gitignored) for local overrides.
+
+Helper inventories checked in for convenience:
+
+- `inventory.ssh-server.yaml` — community Rocky 10 server only
+- `inventory.agent-test.yaml` — community server + Rocky 10 Podman agent
+
+Primary validated path: **SSH Rocky 10 server** (`root@10.66.6.82`) with **Rocky 10 Podman agent** using el10 RPMs from `mock -r rocky-10-x86_64`.
+
+## Prerequisites
+
+| Need | Notes |
+|------|--------|
+| Controller | `bash`, `python3` + PyYAML, `ssh`/`scp`, `podman` (for Podman backend), `mock`/`rpmbuild` (to auto-build Rocky 10 RPMs) |
+| SSH hosts | Key-based login; suites may install/remove OSSEC packages and restart services |
+| Packages | Prefer RPMs/Debs in `testsuite/` (`E2E_PACKAGE_DIR`). Auto-built via mock (`rocky-10-x86_64`) and `build-deb.sh` unless `--no-build-packages` |
+
+## Suites
+
+| Suite | Purpose |
+|-------|---------|
+| `01-install-server` | Install server package/source, start, assert daemons |
+| `02-install-agent` | Install agent, enroll keys, assert connection evidence |
+| `03-feature-smoke` | `ossec-logtest` fixture + syscheck soft smoke |
+| `04-upgrade-server` | Baseline (`E2E_BASE_PACKAGE` or current) → current; preserve config marker |
+| `syscheck/*` | Extended FIM (queue gate, 550/553/554, realtime vs scheduled, filters, report_changes) |
+
+Default `run.sh` runs **01–04** only. Extended syscheck:
+
+```bash
+./testsuite/e2e-linux/run.sh --inventory testsuite/e2e-linux/inventory.ssh-server.yaml --suite syscheck --no-build-packages
+./testsuite/e2e-linux/run.sh --inventory ... --extended   # 01–04 then syscheck/*
+./testsuite/e2e-linux/run.sh --inventory ... --suite 10-queue-gate
+```
+
+Syscheck suites hard-fail on analysisd queue `socketerr` (unlike the soft path in `03-feature-smoke`).
+
+## Environment
+
+- `E2E_INVENTORY` — inventory path
+- `E2E_BACKEND` — `ssh` or `podman`
+- `E2E_PACKAGE_DIR` — where to find/build packages (default: `testsuite/`)
+- `E2E_BASE_PACKAGE` — prior RPM/Deb file or directory for upgrade tests
+- `E2E_TIMEOUT` — assertion wait seconds (default 120)
+- `E2E_KEEP=1` — keep Podman containers / remote scratch
+- `E2E_BUILD_PACKAGES=0` — skip auto package builds (source-install fallback)
+
+## Layout
+
+```
+e2e-linux/
+  run.sh
+  inventory.example.yaml
+  inventory.community.yaml   # gitignored
+  lib/                       # transport, pkg, assert, enroll, artifacts, syscheck
+  suites/
+    01–04*.sh
+    syscheck/                # extended FIM (10–15)
+  fixtures/
+    syscheck/
+  images/rocky10|ubuntu2404
+```
+
+Suites call only `transport_*` helpers — they do not hard-code SSH vs Podman.

--- a/testsuite/e2e-linux/fixtures/sshd-failed-login.log
+++ b/testsuite/e2e-linux/fixtures/sshd-failed-login.log
@@ -1,0 +1,4 @@
+# Example auth-like failure for ossec-logtest / localfile smoke.
+Aug 11 15:00:01 e2e sshd[12345]: Failed password for invalid user e2etest from 203.0.113.10 port 5555 ssh2
+Aug 11 15:00:02 e2e sshd[12345]: Failed password for invalid user e2etest from 203.0.113.10 port 5555 ssh2
+Aug 11 15:00:03 e2e sshd[12345]: Failed password for root from 203.0.113.10 port 5556 ssh2

--- a/testsuite/e2e-linux/fixtures/syscheck/sample.txt
+++ b/testsuite/e2e-linux/fixtures/syscheck/sample.txt
@@ -1,0 +1,2 @@
+line one of sample text for report_changes
+line two stays until edited

--- a/testsuite/e2e-linux/images/rocky10/Containerfile
+++ b/testsuite/e2e-linux/images/rocky10/Containerfile
@@ -1,0 +1,32 @@
+FROM quay.io/rockylinux/rockylinux:10
+
+# Minimal systemd-enabled image for OSSEC package/source E2E installs.
+RUN dnf -y install dnf-plugins-core && \
+    dnf config-manager --set-enabled crb && \
+    dnf -y update && \
+    dnf -y install \
+        systemd \
+        systemd-udev \
+        procps-ng \
+        findutils \
+        tar \
+        gzip \
+        which \
+        python3 \
+        openssl \
+        pcre2 \
+        zlib-ng-compat \
+        libcurl-minimal \
+        file-libs \
+    && dnf clean all \
+    && (cd /lib/systemd/system/sysinit.target.wants/; for i in *; do [ "$i" = "systemd-tmpfiles-setup.service" ] || rm -f "$i"; done) \
+    && rm -f /lib/systemd/system/multi-user.target.wants/* \
+    && rm -f /etc/systemd/system/*.wants/* \
+    && rm -f /lib/systemd/system/local-fs.target.wants/* \
+    && rm -f /lib/systemd/system/sockets.target.wants/*udev* \
+    && rm -f /lib/systemd/system/sockets.target.wants/*initctl* \
+    && rm -f /lib/systemd/system/basic.target.wants/* \
+    && rm -f /lib/systemd/system/anaconda.target.wants/*
+
+VOLUME [ "/sys/fs/cgroup" ]
+CMD ["/usr/sbin/init"]

--- a/testsuite/e2e-linux/images/ubuntu2404/Containerfile
+++ b/testsuite/e2e-linux/images/ubuntu2404/Containerfile
@@ -1,0 +1,32 @@
+FROM ubuntu:24.04
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        systemd \
+        systemd-sysv \
+        dbus \
+        procps \
+        findutils \
+        tar \
+        gzip \
+        ca-certificates \
+        openssl \
+        libpcre2-8-0 \
+        zlib1g \
+        libcurl4 \
+        libmagic1 \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/* \
+    && cd /lib/systemd/system/sysinit.target.wants/ \
+    && for i in *; do [ "$i" = "systemd-tmpfiles-setup.service" ] || rm -f "$i"; done \
+    && rm -f /lib/systemd/system/multi-user.target.wants/* \
+    && rm -f /etc/systemd/system/*.wants/* \
+    && rm -f /lib/systemd/system/local-fs.target.wants/* \
+    && rm -f /lib/systemd/system/sockets.target.wants/*udev* \
+    && rm -f /lib/systemd/system/sockets.target.wants/*initctl* \
+    && rm -f /lib/systemd/system/basic.target.wants/* \
+    && rm -f /lib/systemd/system/anaconda.target.wants/*
+
+VOLUME [ "/sys/fs/cgroup" ]
+CMD ["/sbin/init"]

--- a/testsuite/e2e-linux/inventory.agent-test.yaml
+++ b/testsuite/e2e-linux/inventory.agent-test.yaml
@@ -1,0 +1,14 @@
+hosts:
+  - name: rocky10-community-server
+    backend: ssh
+    ssh: root@10.66.6.82
+    role: server
+    family: rpm
+    distro: rockylinux-10
+
+  - name: rocky10-agent-podman
+    backend: podman
+    image: localhost/ossec-e2e-rocky10
+    role: agent
+    family: rpm
+    server: "10.66.6.82"

--- a/testsuite/e2e-linux/inventory.example.yaml
+++ b/testsuite/e2e-linux/inventory.example.yaml
@@ -1,0 +1,30 @@
+# Example inventory — copy to inventory.community.yaml (gitignored) for local use.
+hosts:
+  - name: rocky10-community-server
+    backend: ssh
+    ssh: root@10.66.6.82
+    role: server
+    family: rpm
+    distro: rockylinux-10
+
+  - name: rocky10-server-podman
+    backend: podman
+    image: localhost/ossec-e2e-rocky10
+    role: server
+    family: rpm
+    distro: rockylinux-10
+
+  - name: rocky10-agent-podman
+    backend: podman
+    image: localhost/ossec-e2e-rocky10
+    role: agent
+    family: rpm
+    # When testing against the community manager:
+    server: "10.66.6.82"
+
+  - name: ubuntu2404-agent-podman
+    backend: podman
+    image: localhost/ossec-e2e-ubuntu2404
+    role: agent
+    family: deb
+    server: "10.66.6.82"

--- a/testsuite/e2e-linux/inventory.ssh-server.yaml
+++ b/testsuite/e2e-linux/inventory.ssh-server.yaml
@@ -1,0 +1,8 @@
+# SSH-only inventory for community Rocky 10 server validation
+hosts:
+  - name: rocky10-community-server
+    backend: ssh
+    ssh: root@10.66.6.82
+    role: server
+    family: rpm
+    distro: rockylinux-10

--- a/testsuite/e2e-linux/lib/artifacts.sh
+++ b/testsuite/e2e-linux/lib/artifacts.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+# Build / locate installable artifacts on the controller.
+
+artifacts_ensure_source_tarball() {
+    local out="$E2E_PACKAGE_DIR/ossec-hids-e2e-src.tar.gz"
+    if [[ -f "$out" && "${E2E_FORCE_TARBALL:-0}" != "1" ]]; then
+        # Refresh if older than 1 hour relative to install.sh mtime is complex; always rebuild lightly.
+        :
+    fi
+    log "creating source tarball $out"
+    mkdir -p "$E2E_PACKAGE_DIR"
+    tar -czf "$out" \
+        --exclude='.git' \
+        --exclude='testsuite/*.rpm' \
+        --exclude='testsuite/*.deb' \
+        --exclude='testsuite/*.tar.gz' \
+        --exclude='src/external/pcre2-10.32' \
+        --exclude='src/external/*.tar.gz' \
+        -C "$ROOT_DIR" \
+        --transform 's,^\./,ossec-hids/,' \
+        .
+    echo "$out"
+}
+
+artifacts_build_rpm_rocky10() {
+    require_cmd mock
+    require_cmd rpmbuild
+    log "building SRPM"
+    (cd "$ROOT_DIR" && ./testsuite/build-srpm.sh)
+    local srpm
+    srpm=$(ls -1t "$TESTSUITE_DIR"/ossec-hids-*.src.rpm 2>/dev/null | head -1)
+    [[ -n "$srpm" ]] || die "no SRPM produced"
+    log "mock rebuild rocky-10-x86_64 from $(basename "$srpm")"
+    local resultdir="$E2E_DIR/mock-rocky10"
+    mkdir -p "$resultdir"
+    mock -r rocky-10-x86_64 --resultdir="$resultdir" --rebuild "$srpm"
+    find "$resultdir" -maxdepth 1 -name 'ossec-hids*.rpm' ! -name '*.src.rpm' -exec cp -f {} "$E2E_PACKAGE_DIR/" \;
+    log "RPM artifacts in $E2E_PACKAGE_DIR:"
+    ls -1 "$E2E_PACKAGE_DIR"/ossec-hids*.rpm 2>/dev/null | grep -v src || true
+}
+
+artifacts_build_deb() {
+    local which="${1:-all}"
+    (cd "$ROOT_DIR" && ./testsuite/build-deb.sh "$which")
+}
+
+artifacts_ensure_for_inventory() {
+    local inventory="$1"
+    local need_rpm=0 need_deb=0
+    local name family
+    while read -r name; do
+        [[ -z "$name" ]] && continue
+        family=$(inventory_get_field "$inventory" "$name" family)
+        case "$family" in
+            rpm) need_rpm=1 ;;
+            deb) need_deb=1 ;;
+        esac
+    done < <(inventory_list_hosts "$inventory" "${E2E_BACKEND:-}")
+
+    if [[ "$need_rpm" == "1" ]]; then
+        if ! pkg_find_rpm server >/dev/null 2>&1 && ! pkg_find_rpm agent >/dev/null 2>&1; then
+            if [[ "${E2E_BUILD_PACKAGES:-1}" == "1" ]]; then
+                artifacts_build_rpm_rocky10
+            else
+                warn "no RPM packages found; suites will use source install"
+            fi
+        fi
+    fi
+    if [[ "$need_deb" == "1" ]]; then
+        if ! pkg_find_deb server >/dev/null 2>&1 && ! pkg_find_deb agent >/dev/null 2>&1; then
+            if [[ "${E2E_BUILD_PACKAGES:-1}" == "1" ]]; then
+                artifacts_build_deb all
+            else
+                warn "no Deb packages found; suites will use source install"
+            fi
+        fi
+    fi
+}

--- a/testsuite/e2e-linux/lib/assert.sh
+++ b/testsuite/e2e-linux/lib/assert.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+# Remote assertions via transport_bash / transport_exec.
+
+assert_cmd() {
+    local desc="$1"
+    shift
+    if transport_exec "$@"; then
+        log "OK: $desc"
+    else
+        die "FAIL: $desc"
+    fi
+}
+
+assert_process() {
+    local name="$1"
+    local start now
+    start=$(date +%s)
+    while true; do
+        if transport_exec pgrep -x "$name" >/dev/null 2>&1; then
+            log "OK: process $name running"
+            return 0
+        fi
+        now=$(date +%s)
+        if (( now - start >= E2E_TIMEOUT )); then
+            die "timeout after ${E2E_TIMEOUT}s waiting for process $name on $HOST_NAME"
+        fi
+        sleep 2
+    done
+}
+
+assert_no_fatal_startup() {
+    transport_bash "
+        set -e
+        logf=$OSSEC_DIR/logs/ossec.log
+        [[ -f \$logf ]] || exit 0
+        if grep -E 'FATAL|CRITICAL' \$logf | grep -viE 'already running|Duplicate' >/dev/null; then
+            echo 'FATAL/CRITICAL lines in ossec.log:' >&2
+            grep -E 'FATAL|CRITICAL' \$logf | tail -20 >&2
+            exit 1
+        fi
+    "
+    log "OK: no FATAL/CRITICAL in ossec.log"
+}
+
+assert_server_daemons() {
+    assert_process ossec-analysisd
+    assert_process ossec-remoted
+    assert_process ossec-syscheckd
+    assert_no_fatal_startup
+}
+
+assert_agent_daemon() {
+    assert_process ossec-agentd
+    assert_no_fatal_startup
+}
+
+assert_remote_grep() {
+    local desc="$1" pattern="$2" path="$3"
+    local start now
+    start=$(date +%s)
+    while true; do
+        if transport_bash "grep -Eq $(printf '%q' "$pattern") $(printf '%q' "$path")"; then
+            log "OK: $desc"
+            return 0
+        fi
+        now=$(date +%s)
+        if (( now - start >= E2E_TIMEOUT )); then
+            die "timeout after ${E2E_TIMEOUT}s waiting for: $desc"
+        fi
+        sleep 2
+    done
+}
+
+assert_logtest_ok() {
+    local fixture_remote="$1"
+    transport_bash "
+        set -e
+        out=\$($OSSEC_DIR/bin/ossec-logtest -q < $(printf '%q' "$fixture_remote") 2>&1 || true)
+        echo \"\$out\" | tee $E2E_REMOTE_TMP/logtest.out >/dev/null
+        echo \"\$out\" | grep -Eqi 'alert|Phase 3|Rule id'
+    "
+    log "OK: ossec-logtest produced rule/alert output"
+}

--- a/testsuite/e2e-linux/lib/common.sh
+++ b/testsuite/e2e-linux/lib/common.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# Shared helpers for e2e-linux (controller-side).
+set -euo pipefail
+
+E2E_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TESTSUITE_DIR="$(cd "$E2E_DIR/.." && pwd)"
+ROOT_DIR="$(cd "$TESTSUITE_DIR/.." && pwd)"
+
+E2E_PACKAGE_DIR="${E2E_PACKAGE_DIR:-$TESTSUITE_DIR}"
+E2E_TIMEOUT="${E2E_TIMEOUT:-120}"
+E2E_KEEP="${E2E_KEEP:-0}"
+E2E_REMOTE_TMP="${E2E_REMOTE_TMP:-/var/tmp/ossec-e2e}"
+E2E_PODMAN_NETWORK="${E2E_PODMAN_NETWORK:-ossec-e2e}"
+OSSEC_DIR="${OSSEC_DIR:-/var/ossec}"
+
+log()  { printf '[e2e] %s\n' "$*"; }
+warn() { printf '[e2e] WARN: %s\n' "$*" >&2; }
+die()  { printf '[e2e] ERROR: %s\n' "$*" >&2; exit 1; }
+
+require_cmd() {
+    command -v "$1" >/dev/null 2>&1 || die "required command not found: $1"
+}
+
+wait_for() {
+    local desc="$1" timeout="${2:-$E2E_TIMEOUT}"
+    shift 2
+    local start now
+    start=$(date +%s)
+    while true; do
+        if "$@"; then
+            return 0
+        fi
+        now=$(date +%s)
+        if (( now - start >= timeout )); then
+            die "timeout after ${timeout}s waiting for: $desc"
+        fi
+        sleep 2
+    done
+}

--- a/testsuite/e2e-linux/lib/enroll.sh
+++ b/testsuite/e2e-linux/lib/enroll.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# Enroll agent against a prepared server host.
+# Uses manage_agents bulk load on the server, then copies the client.keys line to the agent.
+
+enroll_agent_to_server() {
+    local server_inventory="$1"
+    local server_name="$2"
+    local agent_name="${3:-e2e-agent}"
+    local agent_ip="${4:-any}"
+
+    # Save agent host context
+    local A_NAME="$HOST_NAME" A_BACKEND="$HOST_BACKEND" A_SSH="${HOST_SSH:-}" \
+          A_CONTAINER="${HOST_CONTAINER:-}" A_FAMILY="$HOST_FAMILY" A_ROLE="$HOST_ROLE" \
+          A_IMAGE="${HOST_IMAGE:-}" A_DISTRO="${HOST_DISTRO:-}"
+
+    host_load "$server_inventory" "$server_name"
+    transport_prepare
+
+    local keyline keyfile
+    keyfile=$(mktemp)
+    transport_bash "
+        set -e
+        # Drop prior agent with same name
+        if grep -E ' ${agent_name} ' $OSSEC_DIR/etc/client.keys >/dev/null 2>&1; then
+            grep -vE ' ${agent_name} ' $OSSEC_DIR/etc/client.keys > $OSSEC_DIR/etc/client.keys.tmp || true
+            mv $OSSEC_DIR/etc/client.keys.tmp $OSSEC_DIR/etc/client.keys
+            chown root:ossec $OSSEC_DIR/etc/client.keys 2>/dev/null || true
+            chmod 640 $OSSEC_DIR/etc/client.keys 2>/dev/null || true
+        fi
+        printf '%s,%s\n' '$agent_ip' '$agent_name' | $OSSEC_DIR/bin/manage_agents -f -
+        grep -E ' ${agent_name} ' $OSSEC_DIR/etc/client.keys
+        $OSSEC_DIR/bin/ossec-control restart || true
+    " | tee "$keyfile"
+    keyline=$(grep -E " ${agent_name} " "$keyfile" | tail -1 | tr -d '\r')
+    rm -f "$keyfile"
+    [[ -n "$keyline" ]] || die "failed to create agent key for $agent_name on $server_name"
+    log "server key line: $keyline"
+
+    # Restore agent context and install matching key
+    HOST_NAME="$A_NAME" HOST_BACKEND="$A_BACKEND" HOST_SSH="$A_SSH" \
+        HOST_CONTAINER="$A_CONTAINER" HOST_FAMILY="$A_FAMILY" HOST_ROLE="$A_ROLE" \
+        HOST_IMAGE="$A_IMAGE" HOST_DISTRO="$A_DISTRO"
+
+    transport_bash "
+        set -e
+        mkdir -p $OSSEC_DIR/etc
+        printf '%s\n' '$keyline' > $OSSEC_DIR/etc/client.keys
+        chown root:ossec $OSSEC_DIR/etc/client.keys 2>/dev/null || true
+        chmod 640 $OSSEC_DIR/etc/client.keys 2>/dev/null || true
+        $OSSEC_DIR/bin/ossec-control restart
+    "
+    log "OK: enrolled agent $agent_name to server $server_name"
+}

--- a/testsuite/e2e-linux/lib/inventory.sh
+++ b/testsuite/e2e-linux/lib/inventory.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+# Inventory loading (YAML → shell-friendly exports).
+# Requires python3 + PyYAML on the controller.
+
+inventory_list_hosts() {
+    local inventory="$1"
+    local backend_filter="${2:-}"
+    local role_filter="${3:-}"
+    python3 - "$inventory" "$backend_filter" "$role_filter" <<'PY'
+import sys, yaml
+path, backend, role = sys.argv[1], sys.argv[2], sys.argv[3]
+with open(path) as f:
+    data = yaml.safe_load(f) or {}
+hosts = data.get("hosts") or []
+for h in hosts:
+    if backend and h.get("backend") != backend:
+        continue
+    if role and h.get("role") != role:
+        continue
+    name = h.get("name") or ""
+    if not name:
+        continue
+    print(name)
+PY
+}
+
+inventory_get_field() {
+    local inventory="$1" name="$2" field="$3"
+    python3 - "$inventory" "$name" "$field" <<'PY'
+import sys, yaml
+path, name, field = sys.argv[1], sys.argv[2], sys.argv[3]
+with open(path) as f:
+    data = yaml.safe_load(f) or {}
+for h in data.get("hosts") or []:
+    if h.get("name") == name:
+        val = h.get(field, "")
+        if val is None:
+            val = ""
+        if isinstance(val, bool):
+            print("true" if val else "false")
+        else:
+            print(val)
+        break
+else:
+    sys.exit(1)
+PY
+}
+
+# Load host fields into HOST_* globals for the current target.
+host_load() {
+    local inventory="$1" name="$2"
+    HOST_NAME="$name"
+    HOST_BACKEND="$(inventory_get_field "$inventory" "$name" backend)"
+    HOST_ROLE="$(inventory_get_field "$inventory" "$name" role)"
+    HOST_FAMILY="$(inventory_get_field "$inventory" "$name" family)"
+    HOST_DISTRO="$(inventory_get_field "$inventory" "$name" distro || true)"
+    HOST_SSH="$(inventory_get_field "$inventory" "$name" ssh || true)"
+    HOST_IMAGE="$(inventory_get_field "$inventory" "$name" image || true)"
+    HOST_CONTAINER="$(inventory_get_field "$inventory" "$name" container || true)"
+    HOST_SERVER="$(inventory_get_field "$inventory" "$name" server || true)"
+    HOST_REQUIRES="$(inventory_get_field "$inventory" "$name" requires || true)"
+    if [[ -z "${HOST_CONTAINER:-}" && "$HOST_BACKEND" == "podman" ]]; then
+        HOST_CONTAINER="e2e-${HOST_NAME}"
+    fi
+    case "$HOST_BACKEND" in
+        ssh|podman) ;;
+        *) die "host $name: unknown backend '$HOST_BACKEND'" ;;
+    esac
+    case "$HOST_FAMILY" in
+        rpm|deb) ;;
+        *) die "host $name: family must be rpm or deb (got '$HOST_FAMILY')" ;;
+    esac
+    case "$HOST_ROLE" in
+        server|agent) ;;
+        *) die "host $name: role must be server or agent (got '$HOST_ROLE')" ;;
+    esac
+}
+
+host_requires_vm() {
+    [[ "${HOST_REQUIRES:-}" == "vm" ]]
+}

--- a/testsuite/e2e-linux/lib/pkg.sh
+++ b/testsuite/e2e-linux/lib/pkg.sh
@@ -1,0 +1,269 @@
+#!/usr/bin/env bash
+# Package / source install helpers via transport_*.
+
+pkg_find_rpm() {
+    local role="$1" dir="${2:-$E2E_PACKAGE_DIR}"
+    local base server agent
+    base=$(ls -1 "$dir"/ossec-hids-[0-9]*.rpm 2>/dev/null | grep -v '\.src\.rpm$' | grep -Ev 'agent|server|hybrid|mysql|postgres' | sort | tail -1 || true)
+    server=$(ls -1 "$dir"/ossec-hids-server-*.rpm 2>/dev/null | sort | tail -1 || true)
+    agent=$(ls -1 "$dir"/ossec-hids-agent-*.rpm 2>/dev/null | sort | tail -1 || true)
+    case "$role" in
+        server)
+            [[ -n "$base" && -n "$server" ]] || return 1
+            printf '%s\n%s\n' "$base" "$server"
+            ;;
+        agent)
+            [[ -n "$base" && -n "$agent" ]] || return 1
+            printf '%s\n%s\n' "$base" "$agent"
+            ;;
+        *) return 1 ;;
+    esac
+}
+
+pkg_find_deb() {
+    local role="$1" dir="${2:-$E2E_PACKAGE_DIR}"
+    local deb
+    case "$role" in
+        server)
+            deb=$(ls -1 "$dir"/ossec-hids_*.deb 2>/dev/null | grep -v agent | sort | tail -1 || true)
+            ;;
+        agent)
+            deb=$(ls -1 "$dir"/ossec-hids-agent_*.deb 2>/dev/null | sort | tail -1 || true)
+            ;;
+        *) return 1 ;;
+    esac
+    [[ -n "$deb" ]] || return 1
+    printf '%s\n' "$deb"
+}
+
+pkg_stop_ossec() {
+    transport_bash '
+        if [[ -x /var/ossec/bin/ossec-control ]]; then
+            /var/ossec/bin/ossec-control stop || true
+        fi
+        systemctl stop ossec-hids ossec-hids-authd 2>/dev/null || true
+    ' || true
+}
+
+pkg_uninstall() {
+    case "$HOST_FAMILY" in
+        rpm)
+            transport_bash '
+                if command -v dnf >/dev/null 2>&1; then
+                    dnf -y remove "ossec-hids*" 2>/dev/null || true
+                elif command -v yum >/dev/null 2>&1; then
+                    yum -y remove "ossec-hids*" 2>/dev/null || true
+                fi
+                rpm -qa "ossec-hids*" | xargs -r rpm -e --nodeps 2>/dev/null || true
+            ' || true
+            ;;
+        deb)
+            transport_bash '
+                export DEBIAN_FRONTEND=noninteractive
+                apt-get -y remove --purge ossec-hids ossec-hids-agent 2>/dev/null || true
+                dpkg -l "ossec-hids*" 2>/dev/null | awk "/^ii/ {print \$2}" | xargs -r dpkg --purge || true
+            ' || true
+            ;;
+    esac
+}
+
+pkg_install_files() {
+    local remote_dir="$E2E_REMOTE_TMP/pkgs"
+    transport_exec mkdir -p "$remote_dir"
+    local f remote_files=()
+    for f in "$@"; do
+        [[ -f "$f" ]] || die "package not found: $f"
+        local base
+        base=$(basename "$f")
+        log "copying $base → $HOST_NAME:$remote_dir/"
+        transport_copy "$f" "$remote_dir/$base"
+        remote_files+=("$remote_dir/$base")
+    done
+
+    case "$HOST_FAMILY" in
+        rpm)
+            transport_bash "
+                set -e
+                dnf -y install ${remote_files[*]} || rpm -Uvh --force ${remote_files[*]}
+            "
+            ;;
+        deb)
+            transport_bash "
+                set -e
+                export DEBIAN_FRONTEND=noninteractive
+                # Ensure OSSEC users/groups exist before package configure
+                getent group ossec >/dev/null || groupadd -r ossec
+                getent group ossecr >/dev/null || groupadd -r ossecr
+                getent passwd ossec >/dev/null || useradd -r -g ossec -d /var/ossec -s /sbin/nologin ossec
+                getent passwd ossecr >/dev/null || useradd -r -g ossecr -d /var/ossec -s /sbin/nologin ossecr
+                getent passwd ossecm >/dev/null || useradd -r -g ossec -d /var/ossec -s /sbin/nologin ossecm
+                apt-get -qq update || true
+                apt-get -y install ${remote_files[*]} || dpkg -i ${remote_files[*]}
+                dpkg --configure -a || true
+                apt-get -y -f install || true
+            "
+            ;;
+    esac
+}
+
+pkg_write_preloaded() {
+    local role="$1" server_ip="${2:-}"
+    local tmp
+    tmp=$(mktemp)
+    cat >"$tmp" <<EOF
+USER_LANGUAGE="en"
+USER_NO_STOP="y"
+USER_INSTALL_TYPE="$role"
+USER_DIR="/var/ossec"
+USER_DELETE_DIR="y"
+USER_ENABLE_ACTIVE_RESPONSE="n"
+USER_ENABLE_SYSCHECK="y"
+USER_ENABLE_ROOTCHECK="n"
+USER_UPDATE_RULES="y"
+USER_ENABLE_EMAIL="n"
+USER_ENABLE_SYSLOG="n"
+USER_ENABLE_FIREWALL_RESPONSE="n"
+EOF
+    if [[ "$role" == "agent" && -n "$server_ip" ]]; then
+        echo "USER_AGENT_SERVER_IP=\"$server_ip\"" >>"$tmp"
+    fi
+    echo "$tmp"
+}
+
+pkg_source_install() {
+    local role="$1" server_ip="${2:-}"
+    local tarball preloaded remote_tgz remote_preload
+    tarball=$(artifacts_ensure_source_tarball)
+    preloaded=$(pkg_write_preloaded "$role" "$server_ip")
+    remote_tgz="$E2E_REMOTE_TMP/ossec-src.tar.gz"
+    remote_preload="$E2E_REMOTE_TMP/preloaded-vars.conf"
+
+    log "source-install $role on $HOST_NAME"
+    transport_copy "$tarball" "$remote_tgz"
+    transport_copy "$preloaded" "$remote_preload"
+    rm -f "$preloaded"
+
+    case "$HOST_FAMILY" in
+        rpm)
+            transport_bash '
+                set -e
+                if command -v dnf >/dev/null 2>&1; then
+                    dnf -y install gcc make openssl-devel pcre2-devel zlib-devel \
+                        systemd-devel file-devel libcurl-devel tar gzip findutils \
+                        2>/dev/null || dnf -y install gcc make openssl-devel pcre2-devel zlib-devel tar gzip
+                fi
+            '
+            ;;
+        deb)
+            transport_bash '
+                set -e
+                export DEBIAN_FRONTEND=noninteractive
+                apt-get -qq update
+                apt-get -y install build-essential libssl-dev libpcre2-dev zlib1g-dev \
+                    libsystemd-dev libmagic-dev libcurl4-openssl-dev tar gzip
+            '
+            ;;
+    esac
+
+    transport_bash "
+        set -e
+        rm -rf $E2E_REMOTE_TMP/src
+        mkdir -p $E2E_REMOTE_TMP/src
+        tar -xzf $remote_tgz -C $E2E_REMOTE_TMP/src --strip-components=1
+        cp $remote_preload $E2E_REMOTE_TMP/src/etc/preloaded-vars.conf
+        cd $E2E_REMOTE_TMP/src
+        ./install.sh
+    "
+}
+
+pkg_install_role() {
+    local role="$1" server_ip="${2:-}"
+    pkg_stop_ossec
+    local files=()
+    case "$HOST_FAMILY" in
+        rpm)
+            mapfile -t files < <(pkg_find_rpm "$role" || true)
+            ;;
+        deb)
+            mapfile -t files < <(pkg_find_deb "$role" || true)
+            ;;
+    esac
+
+    if ((${#files[@]} > 0)); then
+        log "installing $role packages on $HOST_NAME: ${files[*]}"
+        pkg_uninstall
+        pkg_install_files "${files[@]}"
+    else
+        warn "no $HOST_FAMILY packages for role=$role in $E2E_PACKAGE_DIR; falling back to source install"
+        pkg_uninstall
+        pkg_source_install "$role" "$server_ip"
+    fi
+
+    if [[ "$role" == "agent" && -n "$server_ip" ]]; then
+        # Ensure server IP is set even for package installs.
+        transport_bash "
+            set -e
+            conf=$OSSEC_DIR/etc/ossec.conf
+            if [[ -f \$conf ]]; then
+                if grep -q '<server-ip>' \$conf; then
+                    sed -i 's#<server-ip>.*</server-ip>#<server-ip>$server_ip</server-ip>#' \$conf
+                elif grep -q '<address>' \$conf; then
+                    sed -i 's#<address>.*</address>#<address>$server_ip</address>#' \$conf
+                fi
+            fi
+        "
+    fi
+}
+
+pkg_sanitize_config() {
+    # Package defaults often enable email with placeholder SMTP; disable for E2E.
+    # Remoted requires a non-empty client.keys file.
+    transport_bash "
+        set -e
+        conf=$OSSEC_DIR/etc/ossec.conf
+        [[ -f \$conf ]] || exit 0
+        sed -i 's#<email_notification>yes</email_notification>#<email_notification>no</email_notification>#' \$conf
+        sed -i 's#<smtp_server>smtp.example.com.</smtp_server>#<smtp_server>127.0.0.1</smtp_server>#' \$conf || true
+        mkdir -p $OSSEC_DIR/etc $OSSEC_DIR/logs/alerts $OSSEC_DIR/logs/archives $OSSEC_DIR/logs/firewall $OSSEC_DIR/queue/alerts $OSSEC_DIR/queue/ossec
+        if [[ ! -s $OSSEC_DIR/etc/client.keys ]]; then
+            touch $OSSEC_DIR/etc/client.keys
+            chown root:ossec $OSSEC_DIR/etc/client.keys 2>/dev/null || true
+            chmod 640 $OSSEC_DIR/etc/client.keys 2>/dev/null || true
+            if [[ -x $OSSEC_DIR/bin/manage_agents ]]; then
+                printf 'any,e2e-placeholder\n' | $OSSEC_DIR/bin/manage_agents -f - >/dev/null || true
+            fi
+        fi
+        touch /var/log/secure /var/log/messages /var/log/maillog 2>/dev/null || true
+    "
+}
+
+pkg_start_ossec() {
+    pkg_sanitize_config
+    transport_bash "
+        set -e
+        if command -v systemctl >/dev/null 2>&1 && systemctl list-unit-files ossec-hids.service >/dev/null 2>&1; then
+            systemctl enable ossec-hids >/dev/null 2>&1 || true
+            systemctl stop ossec-hids >/dev/null 2>&1 || true
+        fi
+        $OSSEC_DIR/bin/ossec-control start
+    "
+}
+
+pkg_restart_ossec() {
+    pkg_sanitize_config
+    # Prefer stop/start over restart — analysisd can abort mid-join on restart.
+    transport_bash "
+        set -e
+        $OSSEC_DIR/bin/ossec-control stop || true
+        sleep 3
+        # Clear stale sockets that confuse a fresh analysisd
+        rm -f $OSSEC_DIR/queue/ossec/queue $OSSEC_DIR/queue/alerts/ar $OSSEC_DIR/queue/alerts/execq 2>/dev/null || true
+        mkdir -p $OSSEC_DIR/queue/ossec $OSSEC_DIR/queue/alerts
+        chown ossec:ossec $OSSEC_DIR/queue/ossec $OSSEC_DIR/queue/alerts 2>/dev/null || true
+        $OSSEC_DIR/bin/ossec-control start
+        sleep 2
+        # analysisd must stay alive (no immediate abort)
+        pgrep -x ossec-analysisd >/dev/null
+        pgrep -x ossec-syscheckd >/dev/null
+    "
+}

--- a/testsuite/e2e-linux/lib/podman_target.sh
+++ b/testsuite/e2e-linux/lib/podman_target.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+# Podman systemd target lifecycle + exec/copy.
+
+podman_ensure_network() {
+    if ! podman network exists "$E2E_PODMAN_NETWORK" >/dev/null 2>&1; then
+        log "creating podman network $E2E_PODMAN_NETWORK"
+        podman network create "$E2E_PODMAN_NETWORK" >/dev/null
+    fi
+}
+
+podman_ensure_image() {
+    local image="$1"
+    if podman image exists "$image" >/dev/null 2>&1; then
+        return 0
+    fi
+    # Also accept short name without localhost/ prefix
+    local short="${image#localhost/}"
+    if [[ "$short" != "$image" ]] && podman image exists "$short" >/dev/null 2>&1; then
+        podman tag "$short" "$image" 2>/dev/null || true
+        return 0
+    fi
+    case "$image" in
+        localhost/ossec-e2e-rocky10|ossec-e2e-rocky10)
+            log "building Podman image $image"
+            podman build -t ossec-e2e-rocky10 -t localhost/ossec-e2e-rocky10 "$E2E_DIR/images/rocky10"
+            ;;
+        localhost/ossec-e2e-ubuntu2404|ossec-e2e-ubuntu2404)
+            log "building Podman image $image"
+            podman build -t ossec-e2e-ubuntu2404 -t localhost/ossec-e2e-ubuntu2404 "$E2E_DIR/images/ubuntu2404"
+            ;;
+        *)
+            log "pulling Podman image $image"
+            podman pull "$image"
+            ;;
+    esac
+}
+
+podman_start_target() {
+    local name="$1" image="$2"
+    require_cmd podman
+    podman_ensure_network
+    podman_ensure_image "$image"
+
+    if podman container exists "$name" >/dev/null 2>&1; then
+        local state
+        state=$(podman inspect -f '{{.State.Status}}' "$name" 2>/dev/null || echo missing)
+        if [[ "$state" != "running" ]]; then
+            log "starting existing container $name"
+            podman start "$name" >/dev/null
+        fi
+    else
+        log "creating systemd container $name from $image"
+        podman run -d \
+            --name "$name" \
+            --hostname "$name" \
+            --network "$E2E_PODMAN_NETWORK" \
+            --systemd=always \
+            --tmpfs /run \
+            --tmpfs /tmp \
+            -v /sys/fs/cgroup:/sys/fs/cgroup:ro \
+            "$image"
+    fi
+
+    wait_for "systemd in $name" 90 bash -c \
+        "st=\$(podman exec '$name' systemctl is-system-running 2>/dev/null || true); [[ \"\$st\" == running || \"\$st\" == degraded ]]"
+}
+
+podman_stop_target() {
+    local name="$1"
+    if [[ "${E2E_KEEP}" == "1" ]]; then
+        log "keeping container $name (E2E_KEEP=1)"
+        return 0
+    fi
+    if podman container exists "$name" >/dev/null 2>&1; then
+        log "removing container $name"
+        podman rm -f "$name" >/dev/null
+    fi
+}
+
+podman_exec() {
+    local name="$1"
+    shift
+    podman exec "$name" "$@"
+}
+
+podman_copy() {
+    local src="$1" name="$2" dest="$3"
+    podman cp "$src" "${name}:${dest}"
+}
+
+podman_probe() {
+    local name="$1"
+    podman exec "$name" true
+}

--- a/testsuite/e2e-linux/lib/ssh.sh
+++ b/testsuite/e2e-linux/lib/ssh.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# SSH transport helpers.
+
+ssh_opts() {
+    echo -o BatchMode=yes -o StrictHostKeyChecking=accept-new -o ConnectTimeout=15
+}
+
+ssh_exec() {
+    local target="$1"
+    shift
+    # shellcheck disable=SC2046
+    ssh $(ssh_opts) "$target" "$@"
+}
+
+ssh_sudo() {
+    local target="$1"
+    shift
+    if [[ "$target" == root@* || "$target" == root@*/* ]]; then
+        ssh_exec "$target" "$@"
+    else
+        ssh_exec "$target" sudo -n bash -lc "$(printf '%q ' "$@")"
+    fi
+}
+
+ssh_copy() {
+    local src="$1" target="$2" dest="$3"
+    # shellcheck disable=SC2046
+    scp $(ssh_opts) -q "$src" "${target}:${dest}"
+}
+
+ssh_probe() {
+    local target="$1"
+    ssh_exec "$target" true
+}

--- a/testsuite/e2e-linux/lib/syscheck.sh
+++ b/testsuite/e2e-linux/lib/syscheck.sh
@@ -1,0 +1,260 @@
+#!/usr/bin/env bash
+# Syscheck E2E helpers (controller-side; use with HOST_* + transport_*).
+
+SK_TREE="${SK_TREE:-/opt/e2e-syscheck}"
+SK_DB="${OSSEC_DIR}/queue/syscheck/syscheck"
+SK_ALERTS="${OSSEC_DIR}/logs/alerts/alerts.log"
+SK_LOG="${OSSEC_DIR}/logs/ossec.log"
+
+# Write a unique mark into ossec.log so later greps are scoped to this run.
+sk_stamp_mark() {
+    local tag="${1:-E2E_SYSCHECK_MARK}"
+    SK_MARK_TAG="$tag"
+    transport_bash "echo \"${tag} \$(date -Iseconds)\" >> $SK_LOG"
+}
+
+sk_mark_line() {
+    transport_bash "grep -n '${SK_MARK_TAG:-E2E_SYSCHECK_MARK}' $SK_LOG | tail -1 | cut -d: -f1"
+}
+
+# Run remote grep only on log lines after the last mark.
+sk_log_since_mark() {
+    local pattern="$1"
+    transport_bash "
+        mark=\$(grep -n '${SK_MARK_TAG:-E2E_SYSCHECK_MARK}' $SK_LOG | tail -1 | cut -d: -f1)
+        [[ -n \"\$mark\" ]] || exit 1
+        tail -n +\$mark $SK_LOG | grep -E $(printf '%q' "$pattern")
+    "
+}
+
+sk_alert_since_mark() {
+    local pattern="$1"
+    # alerts.log has no mark; use timestamp window + path patterns from caller.
+    transport_bash "grep -E $(printf '%q' "$pattern") $SK_ALERTS 2>/dev/null | tail -20"
+}
+
+# Replace all <syscheck> blocks with $1 XML fragment; disable rootcheck to cut queue noise.
+# Optional extra global bits (alert_new_files etc.) go inside the syscheck fragment.
+sk_apply_syscheck_xml() {
+    local xml_fragment="$1"
+    local tmp
+    tmp=$(mktemp)
+    printf '%s\n' "$xml_fragment" >"$tmp"
+    transport_copy "$tmp" "$E2E_REMOTE_TMP/sk-fragment.xml"
+    rm -f "$tmp"
+
+    transport_bash "
+        set -e
+        conf=$OSSEC_DIR/etc/ossec.conf
+        cp -a \$conf \$conf.bak.sk-e2e
+        python3 - <<'PY'
+from pathlib import Path
+import re
+p = Path('$OSSEC_DIR/etc/ossec.conf')
+text = p.read_text()
+frag = Path('$E2E_REMOTE_TMP/sk-fragment.xml').read_text().rstrip() + '\n'
+text2 = re.sub(r'[ \t]*<syscheck>.*?</syscheck>\s*', '', text, flags=re.S)
+# Disable rootcheck to avoid competing with syscheck on the MQ during tests
+text2 = re.sub(
+    r'[ \t]*<rootcheck>.*?</rootcheck>\s*',
+    '  <rootcheck>\n    <disabled>yes</disabled>\n  </rootcheck>\n',
+    text2,
+    count=1,
+    flags=re.S,
+)
+if '<rootcheck>' not in text2:
+    text2 = re.sub(r'</ossec_config>', '  <rootcheck>\n    <disabled>yes</disabled>\n  </rootcheck>\n</ossec_config>', text2, count=1)
+text2 = re.sub(r'</ossec_config>', frag + '</ossec_config>', text2, count=1)
+p.write_text(text2)
+PY
+    "
+}
+
+# Minimal realtime tree: one directory, low frequency, optional extras in fragment.
+sk_isolate_tree() {
+    local tree="${1:-$SK_TREE}"
+    local extra_dirs="${2:-}"
+    local extras="${3:-}"
+    SK_TREE="$tree"
+    transport_bash "
+        set -e
+        rm -rf $(printf '%q' "$tree")
+        mkdir -p $(printf '%q' "$tree")
+        echo 'baseline-content' > $(printf '%q' "$tree")/watched.txt
+        rm -f $OSSEC_DIR/queue/syscheck/syscheck $OSSEC_DIR/queue/syscheck/.syscheck.cpt
+        mkdir -p $OSSEC_DIR/queue/syscheck
+        chown -R ossec:ossec $OSSEC_DIR/queue/syscheck 2>/dev/null || true
+    "
+    local fragment
+    fragment=$(cat <<EOF
+  <syscheck>
+    <frequency>30</frequency>
+    <scan_on_start>yes</scan_on_start>
+    <auto_ignore>no</auto_ignore>
+    <alert_new_files>yes</alert_new_files>
+    <directories check_all="yes" realtime="yes">${tree}</directories>
+${extra_dirs}${extras}  </syscheck>
+EOF
+)
+    sk_apply_syscheck_xml "$fragment"
+    pkg_restart_ossec
+    # Stamp after start so stop-time analysisd join timeouts are out of scope.
+    sk_stamp_mark "E2E_SYSCHECK_MARK"
+    sk_wait_analysisd_stable
+    sleep 1
+}
+
+sk_wait_prescan() {
+    local path="${1:-$SK_TREE/watched.txt}"
+    local start now
+    start=$(date +%s)
+    while true; do
+        if transport_bash "
+            mark=\$(grep -n '${SK_MARK_TAG:-E2E_SYSCHECK_MARK}' $SK_LOG | tail -1 | cut -d: -f1)
+            [[ -n \"\$mark\" ]] || exit 1
+            tail -n +\$mark $SK_LOG | grep -F 'Finished creating syscheck database' >/dev/null
+            [[ -f $SK_DB ]]
+            grep -aF $(printf '%q' "$path") $SK_DB >/dev/null 2>&1
+        "; then
+            log "OK: syscheck pre-scan indexed $path"
+            return 0
+        fi
+        now=$(date +%s)
+        if (( now - start >= E2E_TIMEOUT )); then
+            die "timeout waiting for syscheck pre-scan to index $path"
+        fi
+        sleep 2
+    done
+}
+
+sk_wait_ending_scan() {
+    local min_count="${1:-1}"
+    local start now
+    start=$(date +%s)
+    while true; do
+        if transport_bash "
+            mark=\$(grep -n '${SK_MARK_TAG:-E2E_SYSCHECK_MARK}' $SK_LOG | tail -1 | cut -d: -f1)
+            c=\$(tail -n +\$mark $SK_LOG | grep -cF 'Ending syscheck scan' || true)
+            [[ \"\$c\" -ge $min_count ]]
+        "; then
+            log "OK: Ending syscheck scan seen (>= $min_count)"
+            return 0
+        fi
+        now=$(date +%s)
+        if (( now - start >= E2E_TIMEOUT )); then
+            die "timeout waiting for Ending syscheck scan (need >= $min_count)"
+        fi
+        sleep 2
+    done
+}
+
+sk_wait_analysisd_stable() {
+    # Require analysisd + queue for a short dwell. Do not treat stop-time
+    # "timed out joining" lines as failure — those often appear after mark
+    # when we stamp before restart.
+    local start now pid1 pid2
+    start=$(date +%s)
+    while true; do
+        if transport_bash "
+            pgrep -x ossec-analysisd >/dev/null
+            [[ -S $OSSEC_DIR/queue/ossec/queue ]]
+        "; then
+            pid1=$(transport_bash "pgrep -x ossec-analysisd | head -1")
+            sleep 5
+            pid2=$(transport_bash "pgrep -x ossec-analysisd | head -1" || true)
+            if [[ -n "$pid1" && "$pid1" == "$pid2" ]] && \
+               transport_bash "[[ -S $OSSEC_DIR/queue/ossec/queue ]]"; then
+                log "OK: analysisd stable with queue socket (pid $pid1)"
+                return 0
+            fi
+        fi
+        now=$(date +%s)
+        if (( now - start >= 90 )); then
+            die "analysisd not stable (missing process or queue)"
+        fi
+        sleep 2
+    done
+}
+
+sk_assert_no_socketerr_since_mark() {
+    if transport_bash "
+        mark=\$(grep -n '${SK_MARK_TAG:-E2E_SYSCHECK_MARK}' $SK_LOG | tail -1 | cut -d: -f1)
+        tail -n +\$mark $SK_LOG | grep -E 'socketerr \\(not available\\)|Error sending message to queue' >/dev/null
+    "; then
+        die "queue health gate failed: socketerr / send errors since mark"
+    fi
+    log "OK: no socketerr since mark"
+}
+
+sk_assert_db_has() {
+    local path="$1"
+    transport_bash "grep -aF $(printf '%q' "$path") $SK_DB >/dev/null" \
+        || die "syscheck DB missing path: $path"
+    log "OK: DB has $path"
+}
+
+sk_assert_db_lacks() {
+    local path="$1"
+    if transport_bash "[[ -f $SK_DB ]] && grep -aF $(printf '%q' "$path") $SK_DB >/dev/null"; then
+        die "syscheck DB unexpectedly contains: $path"
+    fi
+    log "OK: DB lacks $path"
+}
+
+# Wait for an alert matching pattern (typically Rule: 550 / path / description).
+sk_wait_alert() {
+    local pattern="$1"
+    local desc="${2:-alert matching $pattern}"
+    local start now
+    start=$(date +%s)
+    while true; do
+        if transport_bash "grep -E $(printf '%q' "$pattern") $SK_ALERTS >/dev/null 2>&1"; then
+            # Prefer alerts after our mark time when possible: also require path if provided via pattern
+            log "OK: $desc"
+            return 0
+        fi
+        now=$(date +%s)
+        if (( now - start >= E2E_TIMEOUT )); then
+            die "timeout waiting for $desc"
+        fi
+        sleep 2
+    done
+}
+
+# Clear recent matching noise by truncating alerts log (dedicated E2E host only).
+sk_truncate_alerts() {
+    transport_bash "
+        : > $SK_ALERTS
+        chown ossec:ossec $SK_ALERTS 2>/dev/null || true
+    "
+}
+
+# Queue health gate: isolated tree, first scan clean, content change → rule 550.
+sk_queue_gate() {
+    local tree="${1:-$SK_TREE}"
+    log "=== syscheck queue health gate on $HOST_NAME ==="
+    sk_isolate_tree "$tree"
+    sk_wait_prescan "$tree/watched.txt"
+    sk_wait_ending_scan 1
+    sk_assert_no_socketerr_since_mark
+    sk_truncate_alerts
+
+    transport_bash "echo changed-\$(date +%s)-queue-gate > $(printf '%q' "$tree")/watched.txt"
+
+    _start=$(date +%s)
+    _ok=0
+    while true; do
+        if transport_bash "grep -E 'Rule: 550' -A8 $SK_ALERTS | grep -F $(printf '%q' "$tree/watched.txt") >/dev/null"; then
+            _ok=1
+            break
+        fi
+        _now=$(date +%s)
+        if (( _now - _start >= E2E_TIMEOUT )); then
+            break
+        fi
+        sleep 2
+    done
+    [[ "$_ok" -eq 1 ]] || die "rule 550 integrity alert for $tree/watched.txt not observed"
+    sk_assert_no_socketerr_since_mark
+    log "OK: queue health gate passed (rule 550 observed)"
+}

--- a/testsuite/e2e-linux/lib/transport.sh
+++ b/testsuite/e2e-linux/lib/transport.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+# Backend-agnostic transport: uses HOST_* globals from inventory.sh.
+
+transport_prepare() {
+    case "$HOST_BACKEND" in
+        ssh)
+            require_cmd ssh
+            require_cmd scp
+            [[ -n "${HOST_SSH:-}" ]] || die "host $HOST_NAME: ssh field required"
+            log "probing SSH $HOST_SSH"
+            ssh_probe "$HOST_SSH" || die "cannot SSH to $HOST_SSH"
+            ;;
+        podman)
+            require_cmd podman
+            [[ -n "${HOST_IMAGE:-}" ]] || die "host $HOST_NAME: image field required"
+            podman_start_target "$HOST_CONTAINER" "$HOST_IMAGE"
+            ;;
+    esac
+    transport_exec mkdir -p "$E2E_REMOTE_TMP"
+}
+
+transport_cleanup() {
+    case "$HOST_BACKEND" in
+        podman)
+            podman_stop_target "$HOST_CONTAINER"
+            ;;
+        ssh)
+            # Leave dedicated hosts running; only clear remote scratch if not keeping.
+            if [[ "${E2E_KEEP}" != "1" ]]; then
+                transport_exec rm -rf "$E2E_REMOTE_TMP" || true
+            fi
+            ;;
+    esac
+}
+
+transport_exec() {
+    case "$HOST_BACKEND" in
+        ssh) ssh_exec "$HOST_SSH" "$@" ;;
+        podman) podman_exec "$HOST_CONTAINER" "$@" ;;
+        *) die "transport_exec: no HOST_BACKEND" ;;
+    esac
+}
+
+# Run a remote shell snippet as root (or via sudo on non-root SSH).
+transport_bash() {
+    local script="$1"
+    case "$HOST_BACKEND" in
+        ssh)
+            if [[ "$HOST_SSH" == root@* ]]; then
+                ssh_exec "$HOST_SSH" bash -s <<<"$script"
+            else
+                ssh_exec "$HOST_SSH" sudo -n bash -s <<<"$script"
+            fi
+            ;;
+        podman)
+            podman_exec "$HOST_CONTAINER" bash -c "$script"
+            ;;
+    esac
+}
+
+transport_copy() {
+    local src="$1" dest="$2"
+    case "$HOST_BACKEND" in
+        ssh) ssh_copy "$src" "$HOST_SSH" "$dest" ;;
+        podman) podman_copy "$src" "$HOST_CONTAINER" "$dest" ;;
+    esac
+}
+
+# Resolve a reachable address for this host (agents use this as server IP).
+transport_address() {
+    case "$HOST_BACKEND" in
+        ssh)
+            # user@host → host (IP or DNS)
+            echo "${HOST_SSH#*@}"
+            ;;
+        podman)
+            podman inspect -f '{{range.NetworkSettings.Networks}}{{.IPAddress}}{{end}}' "$HOST_CONTAINER" \
+                | awk 'NF{print; exit}'
+            ;;
+    esac
+}

--- a/testsuite/e2e-linux/run.sh
+++ b/testsuite/e2e-linux/run.sh
@@ -1,0 +1,117 @@
+#!/usr/bin/env bash
+# Linux E2E entrypoint: install / agent / feature smoke / upgrade / syscheck extended.
+# Usage (from repo root):
+#   ./testsuite/e2e-linux/run.sh --inventory testsuite/e2e-linux/inventory.community.yaml
+#   ./testsuite/e2e-linux/run.sh --inventory ... --backend ssh --suite 01-install-server
+#   ./testsuite/e2e-linux/run.sh --inventory ... --suite syscheck
+#   ./testsuite/e2e-linux/run.sh --inventory ... --extended
+set -euo pipefail
+
+E2E_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=/dev/null
+source "$E2E_DIR/lib/common.sh"
+# shellcheck source=/dev/null
+source "$E2E_DIR/lib/inventory.sh"
+# shellcheck source=/dev/null
+source "$E2E_DIR/lib/ssh.sh"
+# shellcheck source=/dev/null
+source "$E2E_DIR/lib/podman_target.sh"
+# shellcheck source=/dev/null
+source "$E2E_DIR/lib/transport.sh"
+# shellcheck source=/dev/null
+source "$E2E_DIR/lib/pkg.sh"
+# shellcheck source=/dev/null
+source "$E2E_DIR/lib/artifacts.sh"
+
+INVENTORY="${E2E_INVENTORY:-}"
+SUITE_FILTER=""
+RUN_EXTENDED=0
+SKIP_PACKAGES=0
+KEEP_GOING=0
+
+usage() {
+    cat <<EOF
+Usage: $0 --inventory FILE [options]
+
+Options:
+  --inventory FILE     Host inventory (YAML)
+  --backend ssh|podman Filter hosts by backend (also E2E_BACKEND)
+  --suite NAME         Run suite(s): 01-install-server, syscheck, 10-queue-gate, ...
+  --extended           Run default 01–04 then suites/syscheck/*
+  --keep-going         Continue after suite host failures
+  --keep               Keep Podman containers / remote scratch (E2E_KEEP=1)
+  --no-build-packages  Do not auto-build missing RPM/Deb artifacts
+  --build-packages     Force package build attempt before suites
+  -h, --help           Show help
+
+Environment:
+  E2E_INVENTORY E2E_BACKEND E2E_PACKAGE_DIR E2E_BASE_PACKAGE
+  E2E_TIMEOUT E2E_KEEP E2E_BUILD_PACKAGES E2E_KEEP_GOING
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --inventory) INVENTORY="$2"; shift 2 ;;
+        --backend) E2E_BACKEND="$2"; export E2E_BACKEND; shift 2 ;;
+        --suite) SUITE_FILTER="$2"; shift 2 ;;
+        --extended) RUN_EXTENDED=1; shift ;;
+        --keep-going) KEEP_GOING=1; E2E_KEEP_GOING=1; export E2E_KEEP_GOING; shift ;;
+        --keep) E2E_KEEP=1; export E2E_KEEP; shift ;;
+        --no-build-packages) E2E_BUILD_PACKAGES=0; export E2E_BUILD_PACKAGES; SKIP_PACKAGES=1; shift ;;
+        --build-packages) E2E_BUILD_PACKAGES=1; export E2E_BUILD_PACKAGES; shift ;;
+        -h|--help) usage; exit 0 ;;
+        *) die "unknown argument: $1" ;;
+    esac
+done
+
+[[ -n "$INVENTORY" ]] || die " --inventory is required (or set E2E_INVENTORY)"
+[[ -f "$INVENTORY" ]] || die "inventory not found: $INVENTORY"
+require_cmd python3
+
+export E2E_KEEP_GOING="${E2E_KEEP_GOING:-$KEEP_GOING}"
+
+log "inventory=$INVENTORY backend=${E2E_BACKEND:-all} package_dir=$E2E_PACKAGE_DIR"
+
+if [[ "$SKIP_PACKAGES" != "1" ]]; then
+    artifacts_ensure_for_inventory "$INVENTORY"
+fi
+
+select_suites() {
+    suites=()
+    if [[ "$RUN_EXTENDED" == "1" ]]; then
+        mapfile -t suites < <(ls -1 "$E2E_DIR/suites"/[0-9]*.sh 2>/dev/null | sort)
+        local _sk=()
+        mapfile -t _sk < <(ls -1 "$E2E_DIR/suites/syscheck"/[0-9]*.sh 2>/dev/null | sort)
+        suites+=("${_sk[@]+"${_sk[@]}"}")
+        return 0
+    fi
+    if [[ -z "$SUITE_FILTER" ]]; then
+        mapfile -t suites < <(ls -1 "$E2E_DIR/suites"/[0-9]*.sh | sort)
+        return 0
+    fi
+    case "$SUITE_FILTER" in
+        syscheck|extended-syscheck)
+            mapfile -t suites < <(ls -1 "$E2E_DIR/suites/syscheck"/[0-9]*.sh | sort)
+            ;;
+        *)
+            local match=""
+            match=$(ls -1 "$E2E_DIR/suites"/${SUITE_FILTER}*.sh 2>/dev/null | head -1 || true)
+            [[ -n "$match" ]] || match=$(ls -1 "$E2E_DIR/suites/syscheck"/${SUITE_FILTER}*.sh 2>/dev/null | head -1 || true)
+            [[ -n "$match" ]] || match=$(ls -1 "$E2E_DIR/suites"/*${SUITE_FILTER}*.sh 2>/dev/null | head -1 || true)
+            [[ -n "$match" ]] || match=$(ls -1 "$E2E_DIR/suites/syscheck"/*${SUITE_FILTER}*.sh 2>/dev/null | head -1 || true)
+            [[ -n "$match" ]] || die "no suite matching '$SUITE_FILTER'"
+            suites+=("$match")
+            ;;
+    esac
+}
+
+select_suites
+((${#suites[@]} > 0)) || die "no suites selected"
+
+for suite in "${suites[@]}"; do
+    log "-------- running $(basename "$(dirname "$suite")")/$(basename "$suite") --------"
+    bash "$suite" "$INVENTORY"
+done
+
+log "E2E finished successfully"

--- a/testsuite/e2e-linux/suites/01-install-server.sh
+++ b/testsuite/e2e-linux/suites/01-install-server.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# 01 — install OSSEC server on inventoried server hosts.
+set -euo pipefail
+
+SUITE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=/dev/null
+source "$SUITE_DIR/../lib/common.sh"
+# shellcheck source=/dev/null
+source "$SUITE_DIR/../lib/inventory.sh"
+# shellcheck source=/dev/null
+source "$SUITE_DIR/../lib/ssh.sh"
+# shellcheck source=/dev/null
+source "$SUITE_DIR/../lib/podman_target.sh"
+# shellcheck source=/dev/null
+source "$SUITE_DIR/../lib/transport.sh"
+# shellcheck source=/dev/null
+source "$SUITE_DIR/../lib/pkg.sh"
+# shellcheck source=/dev/null
+source "$SUITE_DIR/../lib/assert.sh"
+
+INVENTORY="${1:?inventory required}"
+BACKEND_FILTER="${E2E_BACKEND:-}"
+KEEP_GOING="${E2E_KEEP_GOING:-0}"
+failed=0
+
+while read -r name; do
+    [[ -z "$name" ]] && continue
+    host_load "$INVENTORY" "$name"
+    if host_requires_vm && [[ "$HOST_BACKEND" == "podman" ]]; then
+        log "skip $name (requires: vm)"
+        continue
+    fi
+    log "=== 01-install-server: $name ($HOST_BACKEND/$HOST_FAMILY) ==="
+    if ! (
+        transport_prepare
+        pkg_install_role server
+        pkg_start_ossec
+        sleep 3
+        assert_server_daemons
+    ); then
+        failed=1
+        [[ "$KEEP_GOING" == "1" ]] || die "01-install-server failed on $name"
+        warn "continuing after failure on $name"
+    fi
+done < <(inventory_list_hosts "$INVENTORY" "$BACKEND_FILTER" server)
+
+[[ "$failed" -eq 0 ]] || die "01-install-server had failures"
+log "01-install-server: all server hosts OK"

--- a/testsuite/e2e-linux/suites/02-install-agent.sh
+++ b/testsuite/e2e-linux/suites/02-install-agent.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+# 02 — install OSSEC agent and enroll against a server host.
+set -euo pipefail
+
+SUITE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=/dev/null
+source "$SUITE_DIR/../lib/common.sh"
+# shellcheck source=/dev/null
+source "$SUITE_DIR/../lib/inventory.sh"
+# shellcheck source=/dev/null
+source "$SUITE_DIR/../lib/ssh.sh"
+# shellcheck source=/dev/null
+source "$SUITE_DIR/../lib/podman_target.sh"
+# shellcheck source=/dev/null
+source "$SUITE_DIR/../lib/transport.sh"
+# shellcheck source=/dev/null
+source "$SUITE_DIR/../lib/pkg.sh"
+# shellcheck source=/dev/null
+source "$SUITE_DIR/../lib/assert.sh"
+# shellcheck source=/dev/null
+source "$SUITE_DIR/../lib/enroll.sh"
+
+INVENTORY="${1:?inventory required}"
+BACKEND_FILTER="${E2E_BACKEND:-}"
+KEEP_GOING="${E2E_KEEP_GOING:-0}"
+failed=0
+
+mapfile -t SERVERS < <(inventory_list_hosts "$INVENTORY" "$BACKEND_FILTER" server)
+if ((${#SERVERS[@]} == 0)); then
+    # Allow agent backend filter while server is on another backend (e.g. community SSH).
+    mapfile -t SERVERS < <(inventory_list_hosts "$INVENTORY" "" server)
+fi
+((${#SERVERS[@]} > 0)) || die "02-install-agent: no server hosts in inventory"
+SERVER_NAME="${SERVERS[0]}"
+
+# Resolve server address without clobbering later agent context permanently
+host_load "$INVENTORY" "$SERVER_NAME"
+transport_prepare
+if [[ -n "${HOST_SERVER_OVERRIDE:-}" ]]; then
+    SERVER_ADDR="$HOST_SERVER_OVERRIDE"
+else
+    # Prefer explicit inventory server= on agents; else transport address of first server
+    SERVER_ADDR="$(transport_address)"
+fi
+log "using server $SERVER_NAME at $SERVER_ADDR"
+
+while read -r name; do
+    [[ -z "$name" ]] && continue
+    host_load "$INVENTORY" "$name"
+    if host_requires_vm && [[ "$HOST_BACKEND" == "podman" ]]; then
+        log "skip $name (requires: vm)"
+        continue
+    fi
+    # Per-agent override: inventory field "server" may be an IP/hostname
+    local_server_addr="$SERVER_ADDR"
+    if [[ -n "${HOST_SERVER:-}" ]]; then
+        local_server_addr="$HOST_SERVER"
+    fi
+    log "=== 02-install-agent: $name → $local_server_addr ==="
+    if ! (
+        transport_prepare
+        pkg_install_role agent "$local_server_addr"
+        enroll_agent_to_server "$INVENTORY" "$SERVER_NAME" "e2e-${name}" any
+        sleep 3
+        assert_agent_daemon
+        # Connection evidence on manager
+        host_load "$INVENTORY" "$SERVER_NAME"
+        transport_prepare
+        _start=$(date +%s)
+        _ok=0
+        while true; do
+            if transport_bash "grep -E 'e2e-${name}|Active|Connected|is now|agent.start' $OSSEC_DIR/logs/ossec.log | tail -20 | grep -E '.' >/dev/null \
+                || $OSSEC_DIR/bin/manage_agents -l 2>/dev/null | grep -F 'e2e-${name}' >/dev/null"; then
+                _ok=1
+                break
+            fi
+            _now=$(date +%s)
+            if (( _now - _start >= E2E_TIMEOUT )); then
+                break
+            fi
+            sleep 2
+        done
+        [[ "$_ok" -eq 1 ]] || die "agent e2e-${name} not observed on server"
+        log "OK: server saw agent activity for e2e-${name}"
+    ); then
+        failed=1
+        [[ "$KEEP_GOING" == "1" ]] || die "02-install-agent failed on $name"
+        warn "continuing after failure on $name"
+    fi
+done < <(inventory_list_hosts "$INVENTORY" "$BACKEND_FILTER" agent)
+
+[[ "$failed" -eq 0 ]] || die "02-install-agent had failures"
+log "02-install-agent: all agent hosts OK"

--- a/testsuite/e2e-linux/suites/03-feature-smoke.sh
+++ b/testsuite/e2e-linux/suites/03-feature-smoke.sh
@@ -1,0 +1,165 @@
+#!/usr/bin/env bash
+# 03 — feature smoke on server hosts (logtest + syscheck touch).
+set -euo pipefail
+
+SUITE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=/dev/null
+source "$SUITE_DIR/../lib/common.sh"
+# shellcheck source=/dev/null
+source "$SUITE_DIR/../lib/inventory.sh"
+# shellcheck source=/dev/null
+source "$SUITE_DIR/../lib/ssh.sh"
+# shellcheck source=/dev/null
+source "$SUITE_DIR/../lib/podman_target.sh"
+# shellcheck source=/dev/null
+source "$SUITE_DIR/../lib/transport.sh"
+# shellcheck source=/dev/null
+source "$SUITE_DIR/../lib/pkg.sh"
+# shellcheck source=/dev/null
+source "$SUITE_DIR/../lib/assert.sh"
+
+INVENTORY="${1:?inventory required}"
+BACKEND_FILTER="${E2E_BACKEND:-}"
+KEEP_GOING="${E2E_KEEP_GOING:-0}"
+FIXTURES="$SUITE_DIR/../fixtures"
+failed=0
+
+while read -r name; do
+    [[ -z "$name" ]] && continue
+    host_load "$INVENTORY" "$name"
+    if host_requires_vm && [[ "$HOST_BACKEND" == "podman" ]]; then
+        log "skip $name (requires: vm)"
+        continue
+    fi
+    log "=== 03-feature-smoke: $name ==="
+    if ! (
+        transport_prepare
+
+        # Ensure server is up
+        transport_bash "[[ -x $OSSEC_DIR/bin/ossec-control ]]"
+        transport_bash "$OSSEC_DIR/bin/ossec-control status >/dev/null 2>&1 || $OSSEC_DIR/bin/ossec-control start"
+        sleep 2
+
+        # --- logtest fixture ---
+        remote_fixture="$E2E_REMOTE_TMP/sshd-failed-login.log"
+        transport_copy "$FIXTURES/sshd-failed-login.log" "$remote_fixture"
+        assert_logtest_ok "$remote_fixture"
+
+        # Feed into alerts via localfile if present; also append to a monitored path
+        transport_bash "
+            set -e
+            mkdir -p /var/log
+            touch /var/log/secure /var/log/auth.log 2>/dev/null || true
+            cat $remote_fixture >> /var/log/secure 2>/dev/null || cat $remote_fixture >> /var/log/auth.log
+        "
+
+        # --- syscheck: isolate a tiny monitored tree so pre-scan finishes quickly ---
+        transport_bash "
+            set -e
+            mkdir -p /opt/e2e-syscheck
+            echo baseline-\$(date +%s) > /opt/e2e-syscheck/watched.txt
+            conf=$OSSEC_DIR/etc/ossec.conf
+            cp \$conf \$conf.bak.e2e-syscheck
+            rm -f $OSSEC_DIR/queue/syscheck/syscheck $OSSEC_DIR/queue/syscheck/.syscheck.cpt
+            # Stamp the log so we only match post-restart scan completion.
+            echo \"E2E_SYSCHECK_MARK \$(date -Iseconds)\" >> $OSSEC_DIR/logs/ossec.log
+            python3 - <<'PY'
+from pathlib import Path
+import re
+p = Path('$OSSEC_DIR/etc/ossec.conf')
+text = p.read_text()
+block = '''  <syscheck>
+    <frequency>30</frequency>
+    <directories check_all=\"yes\" realtime=\"yes\">/opt/e2e-syscheck</directories>
+  </syscheck>
+'''
+text2, n = re.subn(r'[ \\t]*<syscheck>.*?</syscheck>\\s*', '', text, flags=re.S)
+if n == 0:
+    text2 = text
+text2 = re.sub(r'</ossec_config>', block + '</ossec_config>', text2, count=1)
+p.write_text(text2)
+PY
+            $OSSEC_DIR/bin/ossec-control restart
+        "
+
+        # Wait for a Finished line that appears after our mark
+        _start=$(date +%s)
+        _ok=0
+        while true; do
+            if transport_bash "
+                mark=\$(grep -n 'E2E_SYSCHECK_MARK' $OSSEC_DIR/logs/ossec.log | tail -1 | cut -d: -f1)
+                [[ -n \"\$mark\" ]] || exit 1
+                tail -n +\$mark $OSSEC_DIR/logs/ossec.log | grep -F 'Finished creating syscheck database' >/dev/null
+                [[ -f $OSSEC_DIR/queue/syscheck/syscheck ]]
+                grep -a 'opt/e2e-syscheck/watched.txt' $OSSEC_DIR/queue/syscheck/syscheck >/dev/null
+            "; then
+                _ok=1
+                break
+            fi
+            _now=$(date +%s)
+            if (( _now - _start >= E2E_TIMEOUT )); then
+                break
+            fi
+            sleep 2
+        done
+        [[ "$_ok" -eq 1 ]] || die 'syscheck pre-scan did not index /opt/e2e-syscheck/watched.txt'
+        log "OK: syscheck database contains watched.txt"
+
+        transport_bash "echo changed-\$(date +%s) > /opt/e2e-syscheck/watched.txt"
+
+        # Hard-assert integrity alert (queue readiness remediated; no soft-pass).
+        _start=$(date +%s)
+        _ok=0
+        while true; do
+            if transport_bash "
+                grep -E 'Rule: 550' -A8 $OSSEC_DIR/logs/alerts/alerts.log 2>/dev/null | grep -F 'watched.txt' >/dev/null \
+                || grep -Ei 'Integrity checksum changed' $OSSEC_DIR/logs/alerts/alerts.log 2>/dev/null | grep -F 'watched.txt' >/dev/null
+            "; then
+                _ok=1
+                log "OK: integrity alert observed for watched.txt"
+                break
+            fi
+            _now=$(date +%s)
+            if (( _now - _start >= E2E_TIMEOUT )); then
+                break
+            fi
+            sleep 2
+        done
+        [[ "$_ok" -eq 1 ]] || die 'syscheck smoke: rule 550 / integrity alert for watched.txt not observed'
+
+
+        # Optional: csyslogd config parse / start if binary exists
+        if transport_exec test -x "$OSSEC_DIR/bin/ossec-csyslogd"; then
+            transport_bash "
+                set -e
+                conf=$OSSEC_DIR/etc/ossec.conf
+                if ! grep -q '<syslog_output>' \$conf; then
+                    cp \$conf \$conf.bak.csyslog
+                    awk '
+                        /<\/ossec_config>/ && !done {
+                            print \"  <syslog_output>\"
+                            print \"    <server>127.0.0.1</server>\"
+                            print \"    <port>514</port>\"
+                            print \"    <level>5</level>\"
+                            print \"  </syslog_output>\"
+                            done=1
+                        }
+                        { print }
+                    ' \$conf.bak.csyslog > \$conf
+                    $OSSEC_DIR/bin/ossec-control restart
+                    sleep 3
+                fi
+                pgrep -x ossec-csyslogd >/dev/null
+            " && log "OK: ossec-csyslogd running" || warn "csyslogd smoke skipped/failed (non-fatal)"
+        fi
+
+        log "OK: feature smoke on $name"
+    ); then
+        failed=1
+        [[ "$KEEP_GOING" == "1" ]] || die "03-feature-smoke failed on $name"
+        warn "continuing after failure on $name"
+    fi
+done < <(inventory_list_hosts "$INVENTORY" "$BACKEND_FILTER" server)
+
+[[ "$failed" -eq 0 ]] || die "03-feature-smoke had failures"
+log "03-feature-smoke: all server hosts OK"

--- a/testsuite/e2e-linux/suites/04-upgrade-server.sh
+++ b/testsuite/e2e-linux/suites/04-upgrade-server.sh
@@ -1,0 +1,141 @@
+#!/usr/bin/env bash
+# 04 — upgrade server: BASE_PACKAGE (or prior install) → current artifact.
+set -euo pipefail
+
+SUITE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=/dev/null
+source "$SUITE_DIR/../lib/common.sh"
+# shellcheck source=/dev/null
+source "$SUITE_DIR/../lib/inventory.sh"
+# shellcheck source=/dev/null
+source "$SUITE_DIR/../lib/ssh.sh"
+# shellcheck source=/dev/null
+source "$SUITE_DIR/../lib/podman_target.sh"
+# shellcheck source=/dev/null
+source "$SUITE_DIR/../lib/transport.sh"
+# shellcheck source=/dev/null
+source "$SUITE_DIR/../lib/pkg.sh"
+# shellcheck source=/dev/null
+source "$SUITE_DIR/../lib/assert.sh"
+# shellcheck source=/dev/null
+source "$SUITE_DIR/../lib/artifacts.sh"
+
+INVENTORY="${1:?inventory required}"
+BACKEND_FILTER="${E2E_BACKEND:-}"
+KEEP_GOING="${E2E_KEEP_GOING:-0}"
+BASE_PACKAGE="${E2E_BASE_PACKAGE:-}"
+failed=0
+
+install_base() {
+    if [[ -z "$BASE_PACKAGE" ]]; then
+        log "E2E_BASE_PACKAGE unset: installing current packages as baseline, then reinstalling (upgrade simulation)"
+        pkg_install_role server
+        pkg_start_ossec
+        sleep 2
+        transport_bash "
+            set -e
+            conf=$OSSEC_DIR/etc/ossec.conf
+            grep -q 'e2e-upgrade-marker' \$conf || \
+              sed -i 's#</ossec_config>#  <!-- e2e-upgrade-marker -->\n</ossec_config>#' \$conf
+            id ossec >/dev/null
+        "
+        return 0
+    fi
+
+    local remote="$E2E_REMOTE_TMP/base-pkgs"
+    transport_exec mkdir -p "$remote"
+    if [[ -d "$BASE_PACKAGE" ]]; then
+        local f
+        for f in "$BASE_PACKAGE"/ossec-hids*.rpm "$BASE_PACKAGE"/ossec-hids*.deb; do
+            [[ -f "$f" ]] || continue
+            transport_copy "$f" "$remote/$(basename "$f")"
+        done
+    elif [[ -f "$BASE_PACKAGE" ]]; then
+        transport_copy "$BASE_PACKAGE" "$remote/$(basename "$BASE_PACKAGE")"
+    else
+        die "E2E_BASE_PACKAGE not found: $BASE_PACKAGE"
+    fi
+
+    pkg_stop_ossec
+    pkg_uninstall
+    case "$HOST_FAMILY" in
+        rpm)
+            transport_bash "set -e; dnf -y install $remote/ossec-hids*.rpm || rpm -Uvh $remote/ossec-hids*.rpm"
+            ;;
+        deb)
+            transport_bash "set -e; export DEBIAN_FRONTEND=noninteractive; dpkg -i $remote/ossec-hids*.deb || apt-get -y -f install"
+            ;;
+    esac
+    pkg_start_ossec
+    transport_bash "
+        set -e
+        conf=$OSSEC_DIR/etc/ossec.conf
+        grep -q 'e2e-upgrade-marker' \$conf || \
+          sed -i 's#</ossec_config>#  <!-- e2e-upgrade-marker -->\n</ossec_config>#' \$conf
+    "
+}
+
+upgrade_current() {
+    local files=()
+    case "$HOST_FAMILY" in
+        rpm) mapfile -t files < <(pkg_find_rpm server || true) ;;
+        deb) mapfile -t files < <(pkg_find_deb server || true) ;;
+    esac
+    if ((${#files[@]} > 0)); then
+        pkg_install_files "${files[@]}"
+        return 0
+    fi
+
+    local tarball preloaded
+    tarball=$(artifacts_ensure_source_tarball)
+    preloaded=$(pkg_write_preloaded server)
+    echo 'USER_UPDATE="y"' >>"$preloaded"
+    echo 'USER_DELETE_DIR="n"' >>"$preloaded"
+    transport_copy "$tarball" "$E2E_REMOTE_TMP/ossec-src.tar.gz"
+    transport_copy "$preloaded" "$E2E_REMOTE_TMP/preloaded-vars.conf"
+    rm -f "$preloaded"
+    transport_bash "
+        set -e
+        rm -rf $E2E_REMOTE_TMP/src
+        mkdir -p $E2E_REMOTE_TMP/src
+        tar -xzf $E2E_REMOTE_TMP/ossec-src.tar.gz -C $E2E_REMOTE_TMP/src --strip-components=1
+        cp $E2E_REMOTE_TMP/preloaded-vars.conf $E2E_REMOTE_TMP/src/etc/preloaded-vars.conf
+        cd $E2E_REMOTE_TMP/src
+        ./install.sh
+    "
+}
+
+while read -r name; do
+    [[ -z "$name" ]] && continue
+    host_load "$INVENTORY" "$name"
+    if host_requires_vm && [[ "$HOST_BACKEND" == "podman" ]]; then
+        log "skip $name (requires: vm)"
+        continue
+    fi
+    log "=== 04-upgrade-server: $name ==="
+    if ! (
+        transport_prepare
+        install_base
+        assert_server_daemons
+
+        log "upgrading to current artifact on $name"
+        upgrade_current
+        pkg_restart_ossec
+        sleep 3
+        assert_server_daemons
+
+        transport_bash "
+            set -e
+            grep -q 'e2e-upgrade-marker' $OSSEC_DIR/etc/ossec.conf
+            id ossec >/dev/null
+        "
+        log "OK: upgrade preserved config marker and users on $name"
+    ); then
+        failed=1
+        [[ "$KEEP_GOING" == "1" ]] || die "04-upgrade-server failed on $name"
+        warn "continuing after failure on $name"
+    fi
+done < <(inventory_list_hosts "$INVENTORY" "$BACKEND_FILTER" server)
+
+[[ "$failed" -eq 0 ]] || die "04-upgrade-server had failures"
+log "04-upgrade-server: all server hosts OK"

--- a/testsuite/e2e-linux/suites/syscheck/10-queue-gate.sh
+++ b/testsuite/e2e-linux/suites/syscheck/10-queue-gate.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# 10 — queue health gate: no socketerr + content change → rule 550
+set -euo pipefail
+
+SUITE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+E2E_ROOT="$(cd "$SUITE_DIR/../.." && pwd)"
+# shellcheck source=/dev/null
+source "$E2E_ROOT/lib/common.sh"
+# shellcheck source=/dev/null
+source "$E2E_ROOT/lib/inventory.sh"
+# shellcheck source=/dev/null
+source "$E2E_ROOT/lib/ssh.sh"
+# shellcheck source=/dev/null
+source "$E2E_ROOT/lib/podman_target.sh"
+# shellcheck source=/dev/null
+source "$E2E_ROOT/lib/transport.sh"
+# shellcheck source=/dev/null
+source "$E2E_ROOT/lib/pkg.sh"
+# shellcheck source=/dev/null
+source "$E2E_ROOT/lib/assert.sh"
+# shellcheck source=/dev/null
+source "$E2E_ROOT/lib/syscheck.sh"
+
+INVENTORY="${1:?inventory required}"
+BACKEND_FILTER="${E2E_BACKEND:-}"
+KEEP_GOING="${E2E_KEEP_GOING:-0}"
+failed=0
+
+while read -r name; do
+    [[ -z "$name" ]] && continue
+    host_load "$INVENTORY" "$name"
+    if host_requires_vm && [[ "$HOST_BACKEND" == "podman" ]]; then
+        log "skip $name (requires: vm)"
+        continue
+    fi
+    log "=== 10-queue-gate: $name ==="
+    if ! (
+        transport_prepare
+        transport_bash "[[ -x $OSSEC_DIR/bin/ossec-syscheckd ]]"
+        sk_queue_gate /opt/e2e-syscheck
+    ); then
+        failed=1
+        [[ "$KEEP_GOING" == "1" ]] || die "10-queue-gate failed on $name"
+        warn "continuing after failure on $name"
+    fi
+done < <(inventory_list_hosts "$INVENTORY" "$BACKEND_FILTER" server)
+
+[[ "$failed" -eq 0 ]] || die "10-queue-gate had failures"
+log "10-queue-gate: OK"

--- a/testsuite/e2e-linux/suites/syscheck/11-content-change.sh
+++ b/testsuite/e2e-linux/suites/syscheck/11-content-change.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+# 11 — content change under realtime → rule 550 with checksum evidence
+set -euo pipefail
+
+SUITE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+E2E_ROOT="$(cd "$SUITE_DIR/../.." && pwd)"
+# shellcheck source=/dev/null
+source "$E2E_ROOT/lib/common.sh"
+# shellcheck source=/dev/null
+source "$E2E_ROOT/lib/inventory.sh"
+# shellcheck source=/dev/null
+source "$E2E_ROOT/lib/ssh.sh"
+# shellcheck source=/dev/null
+source "$E2E_ROOT/lib/podman_target.sh"
+# shellcheck source=/dev/null
+source "$E2E_ROOT/lib/transport.sh"
+# shellcheck source=/dev/null
+source "$E2E_ROOT/lib/pkg.sh"
+# shellcheck source=/dev/null
+source "$E2E_ROOT/lib/assert.sh"
+# shellcheck source=/dev/null
+source "$E2E_ROOT/lib/syscheck.sh"
+
+INVENTORY="${1:?inventory required}"
+BACKEND_FILTER="${E2E_BACKEND:-}"
+KEEP_GOING="${E2E_KEEP_GOING:-0}"
+failed=0
+
+while read -r name; do
+    [[ -z "$name" ]] && continue
+    host_load "$INVENTORY" "$name"
+    if host_requires_vm && [[ "$HOST_BACKEND" == "podman" ]]; then
+        log "skip $name (requires: vm)"; continue
+    fi
+    log "=== 11-content-change: $name ==="
+    if ! (
+        transport_prepare
+        sk_isolate_tree /opt/e2e-syscheck
+        sk_wait_prescan /opt/e2e-syscheck/watched.txt
+        sk_assert_no_socketerr_since_mark
+        sk_truncate_alerts
+
+        transport_bash "printf 'content-v2-%s\n' \"\$(date +%s)\" > /opt/e2e-syscheck/watched.txt"
+        _start=$(date +%s)
+        _ok=0
+        while true; do
+            if transport_bash "grep -E 'Rule: 550' -A20 $SK_ALERTS | grep -F '/opt/e2e-syscheck/watched.txt' >/dev/null"; then
+                _ok=1
+                break
+            fi
+            _now=$(date +%s)
+            if (( _now - _start >= E2E_TIMEOUT )); then
+                break
+            fi
+            sleep 2
+        done
+        [[ "$_ok" -eq 1 ]] || die "550 alert missing watched.txt path"
+        transport_bash "
+            grep -E 'Rule: 550' -A30 $SK_ALERTS | grep -Ei 'md5|sha1|sha256|checksum|Integrity' | grep -E '.' >/dev/null
+        " || die "550 alert missing checksum evidence"
+        sk_assert_no_socketerr_since_mark
+        log "OK: content-change → 550"
+    ); then
+        failed=1
+        [[ "$KEEP_GOING" == "1" ]] || die "11-content-change failed on $name"
+        warn "continuing after failure on $name"
+    fi
+done < <(inventory_list_hosts "$INVENTORY" "$BACKEND_FILTER" server)
+
+[[ "$failed" -eq 0 ]] || die "11-content-change had failures"
+log "11-content-change: OK"

--- a/testsuite/e2e-linux/suites/syscheck/12-add-delete.sh
+++ b/testsuite/e2e-linux/suites/syscheck/12-add-delete.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+# 12 — file add → 554 (alert_new_files) and delete → 553
+set -euo pipefail
+
+SUITE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+E2E_ROOT="$(cd "$SUITE_DIR/../.." && pwd)"
+# shellcheck source=/dev/null
+source "$E2E_ROOT/lib/common.sh"
+# shellcheck source=/dev/null
+source "$E2E_ROOT/lib/inventory.sh"
+# shellcheck source=/dev/null
+source "$E2E_ROOT/lib/ssh.sh"
+# shellcheck source=/dev/null
+source "$E2E_ROOT/lib/podman_target.sh"
+# shellcheck source=/dev/null
+source "$E2E_ROOT/lib/transport.sh"
+# shellcheck source=/dev/null
+source "$E2E_ROOT/lib/pkg.sh"
+# shellcheck source=/dev/null
+source "$E2E_ROOT/lib/assert.sh"
+# shellcheck source=/dev/null
+source "$E2E_ROOT/lib/syscheck.sh"
+
+INVENTORY="${1:?inventory required}"
+BACKEND_FILTER="${E2E_BACKEND:-}"
+KEEP_GOING="${E2E_KEEP_GOING:-0}"
+failed=0
+
+while read -r name; do
+    [[ -z "$name" ]] && continue
+    host_load "$INVENTORY" "$name"
+    if host_requires_vm && [[ "$HOST_BACKEND" == "podman" ]]; then
+        log "skip $name (requires: vm)"; continue
+    fi
+    log "=== 12-add-delete: $name ==="
+    if ! (
+        transport_prepare
+        sk_isolate_tree /opt/e2e-syscheck
+        sk_wait_prescan /opt/e2e-syscheck/watched.txt
+        sk_wait_ending_scan 1
+        sk_assert_no_socketerr_since_mark
+        sk_truncate_alerts
+
+        NEWF="newfile-$(date +%s).txt"
+        transport_bash "echo brand-new > /opt/e2e-syscheck/$NEWF"
+        _start=$(date +%s)
+        _ok=0
+        while true; do
+            if transport_bash "grep -E 'Rule: 554' -A8 $SK_ALERTS | grep -F \"$NEWF\" >/dev/null"; then
+                _ok=1
+                break
+            fi
+            _now=$(date +%s)
+            if (( _now - _start >= E2E_TIMEOUT )); then
+                break
+            fi
+            sleep 2
+        done
+        [[ "$_ok" -eq 1 ]] || die "rule 554 for $NEWF not observed"
+        log "OK: rule 554 file added ($NEWF)"
+
+        transport_bash "rm -f /opt/e2e-syscheck/watched.txt"
+        _start=$(date +%s)
+        _ok=0
+        while true; do
+            if transport_bash "grep -E 'Rule: 553' -A8 $SK_ALERTS | grep -F 'watched.txt' >/dev/null"; then
+                _ok=1
+                break
+            fi
+            _now=$(date +%s)
+            if (( _now - _start >= E2E_TIMEOUT )); then
+                break
+            fi
+            sleep 2
+        done
+        [[ "$_ok" -eq 1 ]] || die "rule 553 for watched.txt not observed"
+        sk_assert_no_socketerr_since_mark
+        log "OK: add→554 delete→553"
+    ); then
+        failed=1
+        [[ "$KEEP_GOING" == "1" ]] || die "12-add-delete failed on $name"
+        warn "continuing after failure on $name"
+    fi
+done < <(inventory_list_hosts "$INVENTORY" "$BACKEND_FILTER" server)
+
+[[ "$failed" -eq 0 ]] || die "12-add-delete had failures"
+log "12-add-delete: OK"

--- a/testsuite/e2e-linux/suites/syscheck/13-realtime-vs-scheduled.sh
+++ b/testsuite/e2e-linux/suites/syscheck/13-realtime-vs-scheduled.sh
@@ -1,0 +1,141 @@
+#!/usr/bin/env bash
+# 13 — realtime alert quickly vs scheduled-only after frequency window
+set -euo pipefail
+
+SUITE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+E2E_ROOT="$(cd "$SUITE_DIR/../.." && pwd)"
+# shellcheck source=/dev/null
+source "$E2E_ROOT/lib/common.sh"
+# shellcheck source=/dev/null
+source "$E2E_ROOT/lib/inventory.sh"
+# shellcheck source=/dev/null
+source "$E2E_ROOT/lib/ssh.sh"
+# shellcheck source=/dev/null
+source "$E2E_ROOT/lib/podman_target.sh"
+# shellcheck source=/dev/null
+source "$E2E_ROOT/lib/transport.sh"
+# shellcheck source=/dev/null
+source "$E2E_ROOT/lib/pkg.sh"
+# shellcheck source=/dev/null
+source "$E2E_ROOT/lib/assert.sh"
+# shellcheck source=/dev/null
+source "$E2E_ROOT/lib/syscheck.sh"
+
+INVENTORY="${1:?inventory required}"
+BACKEND_FILTER="${E2E_BACKEND:-}"
+KEEP_GOING="${E2E_KEEP_GOING:-0}"
+failed=0
+
+# Count differential endings: "Ending syscheck scan." without "(forwarding"
+_sk_diff_ending_count() {
+    transport_bash "
+        mark=\$(grep -n 'E2E_SYSCHECK_MARK' $SK_LOG | tail -1 | cut -d: -f1)
+        [[ -n \"\$mark\" ]] || { echo 0; exit 0; }
+        tail -n +\$mark $SK_LOG | grep -F 'Ending syscheck scan.' | grep -vcF '(forwarding' || true
+    "
+}
+
+while read -r name; do
+    [[ -z "$name" ]] && continue
+    host_load "$INVENTORY" "$name"
+    if host_requires_vm && [[ "$HOST_BACKEND" == "podman" ]]; then
+        log "skip $name (requires: vm)"; continue
+    fi
+    log "=== 13-realtime-vs-scheduled: $name ==="
+    if ! (
+        transport_prepare
+        transport_bash "
+            rm -rf /opt/e2e-syscheck-rt /opt/e2e-syscheck-sched
+            mkdir -p /opt/e2e-syscheck-rt /opt/e2e-syscheck-sched
+            echo base-rt > /opt/e2e-syscheck-rt/watched.txt
+            echo base-sched > /opt/e2e-syscheck-sched/watched.txt
+            rm -f $OSSEC_DIR/queue/syscheck/syscheck $OSSEC_DIR/queue/syscheck/.syscheck.cpt
+        "
+        sk_apply_syscheck_xml "$(cat <<'EOF'
+  <syscheck>
+    <frequency>15</frequency>
+    <scan_on_start>yes</scan_on_start>
+    <auto_ignore>no</auto_ignore>
+    <alert_new_files>no</alert_new_files>
+    <directories check_all="yes" realtime="yes">/opt/e2e-syscheck-rt</directories>
+    <directories check_all="yes">/opt/e2e-syscheck-sched</directories>
+  </syscheck>
+EOF
+)"
+        pkg_restart_ossec
+        sk_stamp_mark
+        sk_wait_analysisd_stable
+        sk_wait_prescan /opt/e2e-syscheck-rt/watched.txt
+        sk_assert_db_has /opt/e2e-syscheck-sched/watched.txt
+        sk_wait_ending_scan 1
+        sk_assert_no_socketerr_since_mark
+        sk_truncate_alerts
+
+        # Confirm sched dir is NOT realtime (startup lines may precede mark).
+        transport_bash "
+            line=\$(grep -F \"Monitoring directory: '/opt/e2e-syscheck-sched'\" $SK_LOG | tail -1)
+            [[ -n \"\$line\" ]] || exit 1
+            echo \"\$line\" | grep -F realtime >/dev/null && exit 1
+            rt=\$(grep -F \"Directory set for real time monitoring: '/opt/e2e-syscheck-sched'\" $SK_LOG | tail -1 || true)
+            [[ -z \"\$rt\" ]] || exit 1
+            grep -F \"Monitoring directory: '/opt/e2e-syscheck-rt'\" $SK_LOG | tail -1 | grep -F realtime >/dev/null
+        " || die "sched directory unexpectedly has realtime or is not monitored"
+        log "OK: sched dir monitored without realtime"
+
+        # Realtime: expect alert within 25s
+        transport_bash "echo rt-change-\$(date +%s) > /opt/e2e-syscheck-rt/watched.txt"
+        _start=$(date +%s)
+        _ok=0
+        while true; do
+            if transport_bash "grep -E 'Rule: 550' -A8 $SK_ALERTS | grep -F 'e2e-syscheck-rt/watched.txt' >/dev/null"; then
+                _ok=1
+                break
+            fi
+            _now=$(date +%s)
+            if (( _now - _start >= 25 )); then
+                break
+            fi
+            sleep 1
+        done
+        [[ "$_ok" -eq 1 ]] || die "realtime change did not produce rule 550 within 25s"
+        log "OK: realtime → 550 within 25s"
+
+        # Scheduled: change after baseline; no early alert; then 550 within
+        # frequency+slack with realtime quiet (adaptive select timeout honors
+        # <frequency> instead of blocking for SYSCHECK_WAIT).
+        before_diff=$(_sk_diff_ending_count)
+        before_diff=${before_diff:-0}
+        transport_bash "echo sched-change-\$(date +%s) > /opt/e2e-syscheck-sched/watched.txt"
+        sleep 8
+        if transport_bash "grep -E 'Rule: 550' -A8 $SK_ALERTS | grep -F 'e2e-syscheck-sched/watched.txt' >/dev/null"; then
+            die "scheduled-only path alerted too early (expected no realtime)"
+        fi
+        log "OK: scheduled path had no early alert (diff endings before=$before_diff)"
+
+        _start=$(date +%s)
+        _ok=0
+        while true; do
+            if transport_bash "grep -E 'Rule: 550' -A8 $SK_ALERTS | grep -F 'e2e-syscheck-sched/watched.txt' >/dev/null"; then
+                _ok=1
+                break
+            fi
+            transport_bash "pgrep -x ossec-analysisd >/dev/null" || die "analysisd died during scheduled wait"
+            _now=$(date +%s)
+            # frequency=15 plus scan overhead / slack
+            if (( _now - _start >= 60 )); then
+                after_diff=$(_sk_diff_ending_count)
+                die "scheduled path did not produce rule 550 within 60s (diff endings before=$before_diff after=${after_diff:-?})"
+            fi
+            sleep 3
+        done
+        [[ "$_ok" -eq 1 ]] || die "scheduled path did not produce rule 550"
+        log "OK: scheduled path → 550 after scan (no RT nudge)"
+    ); then
+        failed=1
+        [[ "$KEEP_GOING" == "1" ]] || die "13-realtime-vs-scheduled failed on $name"
+        warn "continuing after failure on $name"
+    fi
+done < <(inventory_list_hosts "$INVENTORY" "$BACKEND_FILTER" server)
+
+[[ "$failed" -eq 0 ]] || die "13-realtime-vs-scheduled had failures"
+log "13-realtime-vs-scheduled: OK"

--- a/testsuite/e2e-linux/suites/syscheck/14-ignore-restrict-norecurse.sh
+++ b/testsuite/e2e-linux/suites/syscheck/14-ignore-restrict-norecurse.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+# 14 — ignore / restrict / no_recurse → DB presence/absence
+set -euo pipefail
+
+SUITE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+E2E_ROOT="$(cd "$SUITE_DIR/../.." && pwd)"
+# shellcheck source=/dev/null
+source "$E2E_ROOT/lib/common.sh"
+# shellcheck source=/dev/null
+source "$E2E_ROOT/lib/inventory.sh"
+# shellcheck source=/dev/null
+source "$E2E_ROOT/lib/ssh.sh"
+# shellcheck source=/dev/null
+source "$E2E_ROOT/lib/podman_target.sh"
+# shellcheck source=/dev/null
+source "$E2E_ROOT/lib/transport.sh"
+# shellcheck source=/dev/null
+source "$E2E_ROOT/lib/pkg.sh"
+# shellcheck source=/dev/null
+source "$E2E_ROOT/lib/assert.sh"
+# shellcheck source=/dev/null
+source "$E2E_ROOT/lib/syscheck.sh"
+
+INVENTORY="${1:?inventory required}"
+BACKEND_FILTER="${E2E_BACKEND:-}"
+KEEP_GOING="${E2E_KEEP_GOING:-0}"
+failed=0
+
+while read -r name; do
+    [[ -z "$name" ]] && continue
+    host_load "$INVENTORY" "$name"
+    if host_requires_vm && [[ "$HOST_BACKEND" == "podman" ]]; then
+        log "skip $name (requires: vm)"; continue
+    fi
+    log "=== 14-ignore-restrict-norecurse: $name ==="
+    if ! (
+        transport_prepare
+        transport_bash "
+            set -e
+            rm -rf /opt/e2e-syscheck
+            mkdir -p /opt/e2e-syscheck/subdir /opt/e2e-syscheck/ignored
+            echo keep > /opt/e2e-syscheck/keep.conf
+            echo skip > /opt/e2e-syscheck/skip.log
+            echo deep > /opt/e2e-syscheck/subdir/deep.conf
+            echo ign > /opt/e2e-syscheck/ignored/secret.conf
+            rm -f $OSSEC_DIR/queue/syscheck/syscheck $OSSEC_DIR/queue/syscheck/.syscheck.cpt
+        "
+        sk_apply_syscheck_xml "$(cat <<'EOF'
+  <syscheck>
+    <frequency>86400</frequency>
+    <scan_on_start>yes</scan_on_start>
+    <auto_ignore>no</auto_ignore>
+    <alert_new_files>no</alert_new_files>
+    <directories check_all="yes" restrict=".conf$" no_recurse="yes">/opt/e2e-syscheck</directories>
+    <ignore>/opt/e2e-syscheck/ignored</ignore>
+  </syscheck>
+EOF
+)"
+        pkg_restart_ossec
+        sk_stamp_mark
+        sk_wait_analysisd_stable
+        sleep 1
+
+        # Wait for Finished + DB file
+        _start=$(date +%s)
+        while true; do
+            if transport_bash "
+                mark=\$(grep -n 'E2E_SYSCHECK_MARK' $SK_LOG | tail -1 | cut -d: -f1)
+                tail -n +\$mark $SK_LOG | grep -F 'Finished creating syscheck database' >/dev/null
+                [[ -f $SK_DB ]]
+            "; then
+                break
+            fi
+            _now=$(date +%s)
+            if (( _now - _start >= E2E_TIMEOUT )); then
+                die "prescan did not finish for filter suite"
+            fi
+            sleep 2
+        done
+
+        sk_assert_db_has /opt/e2e-syscheck/keep.conf
+        sk_assert_db_lacks /opt/e2e-syscheck/skip.log
+        sk_assert_db_lacks /opt/e2e-syscheck/subdir/deep.conf
+        sk_assert_db_lacks /opt/e2e-syscheck/ignored/secret.conf
+        log "OK: ignore/restrict/no_recurse DB filters"
+    ); then
+        failed=1
+        [[ "$KEEP_GOING" == "1" ]] || die "14-ignore-restrict-norecurse failed on $name"
+        warn "continuing after failure on $name"
+    fi
+done < <(inventory_list_hosts "$INVENTORY" "$BACKEND_FILTER" server)
+
+[[ "$failed" -eq 0 ]] || die "14-ignore-restrict-norecurse had failures"
+log "14-ignore-restrict-norecurse: OK"

--- a/testsuite/e2e-linux/suites/syscheck/15-report-changes-nodiff.sh
+++ b/testsuite/e2e-linux/suites/syscheck/15-report-changes-nodiff.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+# 15 — report_changes diff in alert; nodiff truncates content
+set -euo pipefail
+
+SUITE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+E2E_ROOT="$(cd "$SUITE_DIR/../.." && pwd)"
+# shellcheck source=/dev/null
+source "$E2E_ROOT/lib/common.sh"
+# shellcheck source=/dev/null
+source "$E2E_ROOT/lib/inventory.sh"
+# shellcheck source=/dev/null
+source "$E2E_ROOT/lib/ssh.sh"
+# shellcheck source=/dev/null
+source "$E2E_ROOT/lib/podman_target.sh"
+# shellcheck source=/dev/null
+source "$E2E_ROOT/lib/transport.sh"
+# shellcheck source=/dev/null
+source "$E2E_ROOT/lib/pkg.sh"
+# shellcheck source=/dev/null
+source "$E2E_ROOT/lib/assert.sh"
+# shellcheck source=/dev/null
+source "$E2E_ROOT/lib/syscheck.sh"
+
+INVENTORY="${1:?inventory required}"
+BACKEND_FILTER="${E2E_BACKEND:-}"
+KEEP_GOING="${E2E_KEEP_GOING:-0}"
+FIXTURE="$E2E_ROOT/fixtures/syscheck/sample.txt"
+failed=0
+
+while read -r name; do
+    [[ -z "$name" ]] && continue
+    host_load "$INVENTORY" "$name"
+    if host_requires_vm && [[ "$HOST_BACKEND" == "podman" ]]; then
+        log "skip $name (requires: vm)"; continue
+    fi
+    log "=== 15-report-changes-nodiff: $name ==="
+    if ! (
+        transport_prepare
+        transport_bash "
+            set -e
+            rm -rf /opt/e2e-syscheck
+            mkdir -p /opt/e2e-syscheck
+            rm -f $OSSEC_DIR/queue/syscheck/syscheck $OSSEC_DIR/queue/syscheck/.syscheck.cpt
+        "
+        transport_copy "$FIXTURE" /opt/e2e-syscheck/report.txt
+        transport_copy "$FIXTURE" /opt/e2e-syscheck/secret.txt
+        # watched.txt also required by helpers that may look for it — create baseline
+        transport_bash "cp /opt/e2e-syscheck/report.txt /opt/e2e-syscheck/watched.txt"
+
+        sk_apply_syscheck_xml "$(cat <<'EOF'
+  <syscheck>
+    <frequency>60</frequency>
+    <scan_on_start>yes</scan_on_start>
+    <auto_ignore>no</auto_ignore>
+    <alert_new_files>yes</alert_new_files>
+    <directories check_all="yes" realtime="yes" report_changes="yes">/opt/e2e-syscheck</directories>
+    <nodiff>/opt/e2e-syscheck/secret.txt</nodiff>
+  </syscheck>
+EOF
+)"
+        pkg_restart_ossec
+        sk_stamp_mark
+        sk_wait_analysisd_stable
+        sk_wait_prescan /opt/e2e-syscheck/report.txt
+        sk_assert_db_has /opt/e2e-syscheck/secret.txt
+        sk_wait_ending_scan 1
+        sk_assert_no_socketerr_since_mark
+        sk_truncate_alerts
+
+        # report_changes: edit report.txt → expect diff hunks in alert
+        transport_bash "
+            printf '%s\n' 'line one CHANGED for report_changes' 'line two stays until edited' > /opt/e2e-syscheck/report.txt
+        "
+        sk_wait_alert 'report.txt' "alert for report.txt change"
+        transport_bash "
+            grep -E 'Rule: 550' -A80 $SK_ALERTS | grep -F 'report.txt' -A40 | grep -E '@@|^[-+]|What changed|CHANGED' | grep -E '.' >/dev/null
+        " || die "report_changes alert missing diff evidence"
+
+        # nodiff: edit secret.txt → truncated marker, no real content from fixture
+        sk_truncate_alerts
+        transport_bash "
+            printf '%s\n' 'SECRET-VALUE-SHOULD-NOT-APPEAR' 'line two' > /opt/e2e-syscheck/secret.txt
+        "
+        sk_wait_alert 'secret.txt' "alert for secret.txt change"
+        transport_bash "
+            block=\$(grep -E 'Rule: 550' -A80 $SK_ALERTS | grep -F 'secret.txt' -A40)
+            echo \"\$block\" | grep -F 'Diff truncated because nodiff option' >/dev/null
+            ! echo \"\$block\" | grep -F 'SECRET-VALUE-SHOULD-NOT-APPEAR' >/dev/null
+        " || die "nodiff did not truncate / leaked secret content"
+        sk_assert_no_socketerr_since_mark
+        log "OK: report_changes + nodiff"
+    ); then
+        failed=1
+        [[ "$KEEP_GOING" == "1" ]] || die "15-report-changes-nodiff failed on $name"
+        warn "continuing after failure on $name"
+    fi
+done < <(inventory_list_hosts "$INVENTORY" "$BACKEND_FILTER" server)
+
+[[ "$failed" -eq 0 ]] || die "15-report-changes-nodiff had failures"
+log "15-report-changes-nodiff: OK"

--- a/testsuite/run-all.sh
+++ b/testsuite/run-all.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# Run compile matrix, then Linux E2E on success.
+# Usage (repo root):
+#   ./testsuite/run-all.sh [build-test args...] -- [e2e-linux/run.sh args...]
+#   ./testsuite/run-all.sh --inventory testsuite/e2e-linux/inventory.community.yaml --backend ssh
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+BUILD_ARGS=()
+E2E_ARGS=()
+seen_e2e=0
+
+# Arguments before the first E2E-only flag go to build-test if they look like distro names;
+# once we see --inventory/--backend/--suite/etc, remaining args go to e2e.
+for arg in "$@"; do
+    if [[ "$seen_e2e" -eq 1 ]]; then
+        E2E_ARGS+=("$arg")
+        continue
+    fi
+    case "$arg" in
+        --)
+            seen_e2e=1
+            ;;
+        --inventory|--backend|--suite|--keep|--keep-going|--no-build-packages|--build-packages)
+            seen_e2e=1
+            E2E_ARGS+=("$arg")
+            ;;
+        --inventory=*|--backend=*|--suite=*)
+            seen_e2e=1
+            E2E_ARGS+=("$arg")
+            ;;
+        *)
+            if [[ "$arg" == -* && "$seen_e2e" -eq 0 ]]; then
+                # Unknown dash arg: treat as E2E
+                seen_e2e=1
+                E2E_ARGS+=("$arg")
+            else
+                BUILD_ARGS+=("$arg")
+            fi
+            ;;
+    esac
+done
+
+echo "[run-all] compile: ./testsuite/build-test/build.sh ${BUILD_ARGS[*]:-}"
+(cd "$ROOT_DIR" && ./testsuite/build-test/build.sh "${BUILD_ARGS[@]+"${BUILD_ARGS[@]}"}")
+
+if ((${#E2E_ARGS[@]} == 0)); then
+    echo "[run-all] no E2E args; skipping e2e-linux (pass --inventory ... to run)"
+    exit 0
+fi
+
+echo "[run-all] e2e: ./testsuite/e2e-linux/run.sh ${E2E_ARGS[*]}"
+(cd "$ROOT_DIR" && ./testsuite/e2e-linux/run.sh "${E2E_ARGS[@]}")


### PR DESCRIPTION
Bind analysisd's MQ early, wake recv on shutdown, and use adaptive syscheck idle waits so short <frequency> is not capped by SYSCHECK_WAIT. Add Linux E2E (including syscheck suites) to harden these behaviors.